### PR TITLE
🔀 feat(HU-01): BE-01 · Diseñar tablas y crear entidades base

### DIFF
--- a/transparencia-backend/src/main/java/pe/gob/saip/backend/model/entity/Administrador.java
+++ b/transparencia-backend/src/main/java/pe/gob/saip/backend/model/entity/Administrador.java
@@ -1,0 +1,35 @@
+package pe.gob.saip.backend.model.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.PrimaryKeyJoinColumn;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+@Entity
+@Table(name = "administradores")
+@PrimaryKeyJoinColumn(name = "id_usuario")
+public class Administrador extends Usuario {
+
+    @NotBlank(message = "El nombre completo no puede estar vacio")
+    @Column(name = "nombre_completo", nullable = false, length = 200)
+    private String nombreCompleto;
+
+    @Column(length = 100)
+    private String rol;
+
+    @Column(length = 500)
+    private String permisos;
+
+    public Long getId() {
+        return this.getIdUsuario();
+    }
+}

--- a/transparencia-backend/src/main/java/pe/gob/saip/backend/model/entity/Ciudadano.java
+++ b/transparencia-backend/src/main/java/pe/gob/saip/backend/model/entity/Ciudadano.java
@@ -1,0 +1,57 @@
+package pe.gob.saip.backend.model.entity;
+
+import com.transparencia.api.model.entity.Apelacion;
+import com.transparencia.api.model.entity.Solicitud;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.PrimaryKeyJoinColumn;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+@Entity
+@Table(name = "ciudadanos")
+@PrimaryKeyJoinColumn(name = "id_usuario")
+public class Ciudadano extends Usuario {
+
+    @NotBlank(message = "El DNI no puede estar vacio")
+    @Pattern(regexp = "\\d{8}", message = "El DNI debe tener 8 digitos")
+    @Column(nullable = false, unique = true, length = 8)
+    private String dni;
+
+    @NotBlank(message = "El nombre completo no puede estar vacio")
+    @Column(name = "nombre_completo", nullable = false, length = 200)
+    private String nombreCompleto;
+
+    @Column(length = 15)
+    private String telefono;
+
+    @Column(length = 200)
+    private String direccion;
+
+    @OneToMany(mappedBy = "ciudadano", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
+    private List<Solicitud> solicitudes;
+
+    @OneToMany(mappedBy = "ciudadano", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
+    private List<Apelacion> apelaciones;
+
+    public Long getId() {
+        return this.getIdUsuario();
+    }
+
+    public String getNombres() {
+        return this.nombreCompleto;
+    }
+}

--- a/transparencia-backend/src/main/java/pe/gob/saip/backend/model/entity/Entidad.java
+++ b/transparencia-backend/src/main/java/pe/gob/saip/backend/model/entity/Entidad.java
@@ -1,0 +1,101 @@
+package pe.gob.saip.backend.model.entity;
+
+import com.transparencia.api.model.entity.Solicitud;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "entidades", indexes = {
+    @Index(name = "idx_entidad_acronimo", columnList = "acronimo", unique = true)
+})
+public class Entidad {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id_entidad")
+    private Long idEntidad;
+
+    @NotBlank(message = "El nombre de la entidad no puede estar vacio")
+    @Column(nullable = false, length = 200)
+    private String nombre;
+
+    @NotBlank(message = "El acronimo no puede estar vacio")
+    @Column(nullable = false, unique = true, length = 20)
+    private String acronimo;
+
+    @Column(length = 500)
+    private String descripcion;
+
+    @Column(name = "fecha_registro", nullable = false)
+    private LocalDateTime fechaRegistro;
+
+    @Column(nullable = false)
+    private Boolean activa;
+
+    @Column(length = 300)
+    private String direccion;
+
+    @Column(length = 20)
+    private String telefono;
+
+    @Column(length = 100)
+    private String email;
+
+    @Column(length = 20)
+    private String estado;
+
+    @Transient
+    private long solicitudesAsignadas;
+
+    @Transient
+    private long pendientes;
+
+    @Transient
+    private long respondidas;
+
+    @Transient
+    private long vencidas;
+
+    @Transient
+    private int tasaCumplimiento;
+
+    @OneToMany(mappedBy = "entidad", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
+    private List<Funcionario> funcionarios;
+
+    @OneToMany(mappedBy = "entidad", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
+    private List<Solicitud> solicitudes;
+
+    @PrePersist
+    protected void onCreate() {
+        fechaRegistro = LocalDateTime.now();
+        if (activa == null) {
+            activa = true;
+        }
+        if (estado == null) {
+            estado = "Activa";
+        }
+    }
+
+    public Long getId() {
+        return this.idEntidad;
+    }
+}

--- a/transparencia-backend/src/main/java/pe/gob/saip/backend/model/entity/Funcionario.java
+++ b/transparencia-backend/src/main/java/pe/gob/saip/backend/model/entity/Funcionario.java
@@ -1,0 +1,52 @@
+package pe.gob.saip.backend.model.entity;
+
+import com.transparencia.api.model.entity.Respuesta;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.PrimaryKeyJoinColumn;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+@Entity
+@Table(name = "funcionarios")
+@PrimaryKeyJoinColumn(name = "id_usuario")
+public class Funcionario extends Usuario {
+
+    @NotBlank(message = "El nombre completo no puede estar vacio")
+    @Column(name = "nombre_completo", nullable = false, length = 200)
+    private String nombreCompleto;
+
+    @Column(length = 100)
+    private String cargo;
+
+    @Column(length = 100)
+    private String area;
+
+    @Column(length = 20)
+    private String telefono;
+
+    @ManyToOne
+    @JoinColumn(name = "id_entidad", nullable = false)
+    private Entidad entidad;
+
+    @OneToMany(mappedBy = "funcionario", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
+    private List<Respuesta> respuestas;
+
+    public Long getId() {
+        return this.getIdUsuario();
+    }
+}

--- a/transparencia-backend/src/main/java/pe/gob/saip/backend/model/entity/MiembroTTAIP.java
+++ b/transparencia-backend/src/main/java/pe/gob/saip/backend/model/entity/MiembroTTAIP.java
@@ -1,0 +1,46 @@
+package pe.gob.saip.backend.model.entity;
+
+import com.transparencia.api.model.entity.Resolucion;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.PrimaryKeyJoinColumn;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+@Entity
+@Table(name = "miembros_ttaip")
+@PrimaryKeyJoinColumn(name = "id_usuario")
+public class MiembroTTAIP extends Usuario {
+
+    @NotBlank(message = "El nombre completo no puede estar vacio")
+    @Column(name = "nombre_completo", nullable = false, length = 200)
+    private String nombreCompleto;
+
+    @Column(length = 100)
+    private String cargo;
+
+    @Column(length = 30)
+    private String sala;
+
+    @Column(length = 500)
+    private String especialidad;
+
+    @OneToMany(mappedBy = "miembroTTAIP", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
+    private List<Resolucion> resoluciones;
+
+    public Long getId() {
+        return this.getIdUsuario();
+    }
+}

--- a/transparencia-backend/src/main/java/pe/gob/saip/backend/model/entity/Usuario.java
+++ b/transparencia-backend/src/main/java/pe/gob/saip/backend/model/entity/Usuario.java
@@ -1,0 +1,70 @@
+package pe.gob.saip.backend.model.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "usuarios")
+@Inheritance(strategy = InheritanceType.JOINED)
+public class Usuario {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id_usuario")
+    private Long idUsuario;
+
+    @NotBlank(message = "El email no puede estar vacio")
+    @Email(message = "Debe ser un email valido")
+    @Column(nullable = false, unique = true, length = 100)
+    private String email;
+
+    @NotBlank(message = "La contrasena no puede estar vacia")
+    @Column(nullable = false, length = 255)
+    private String password;
+
+    @NotNull(message = "El tipo de usuario no puede ser nulo")
+    @Enumerated(EnumType.STRING)
+    @Column(name = "tipo_usuario", nullable = false, length = 20)
+    private TipoUsuario tipoUsuario;
+
+    @Column(name = "fecha_registro", nullable = false)
+    private LocalDateTime fechaRegistro;
+
+    @Column(nullable = false)
+    private Boolean activo;
+
+    @PrePersist
+    protected void onCreate() {
+        fechaRegistro = LocalDateTime.now();
+        if (activo == null) {
+            activo = true;
+        }
+    }
+
+    public enum TipoUsuario {
+        CIUDADANO,
+        FUNCIONARIO,
+        TTAIP,
+        ADMINISTRADOR
+    }
+}

--- a/transparencia-backend/src/main/java/pe/gob/saip/backend/repository/AdministradorRepository.java
+++ b/transparencia-backend/src/main/java/pe/gob/saip/backend/repository/AdministradorRepository.java
@@ -1,0 +1,9 @@
+package pe.gob.saip.backend.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import pe.gob.saip.backend.model.entity.Administrador;
+
+@Repository
+public interface AdministradorRepository extends JpaRepository<Administrador, Long> {
+}

--- a/transparencia-backend/src/main/java/pe/gob/saip/backend/repository/CiudadanoRepository.java
+++ b/transparencia-backend/src/main/java/pe/gob/saip/backend/repository/CiudadanoRepository.java
@@ -1,0 +1,12 @@
+package pe.gob.saip.backend.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import pe.gob.saip.backend.model.entity.Ciudadano;
+
+import java.util.Optional;
+
+@Repository
+public interface CiudadanoRepository extends JpaRepository<Ciudadano, Long> {
+    Optional<Ciudadano> findByDni(String dni);
+}

--- a/transparencia-backend/src/main/java/pe/gob/saip/backend/repository/EntidadRepository.java
+++ b/transparencia-backend/src/main/java/pe/gob/saip/backend/repository/EntidadRepository.java
@@ -1,0 +1,14 @@
+package pe.gob.saip.backend.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import pe.gob.saip.backend.model.entity.Entidad;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface EntidadRepository extends JpaRepository<Entidad, Long> {
+    Optional<Entidad> findByAcronimo(String acronimo);
+    List<Entidad> findByActivaTrue();
+}

--- a/transparencia-backend/src/main/java/pe/gob/saip/backend/repository/FuncionarioRepository.java
+++ b/transparencia-backend/src/main/java/pe/gob/saip/backend/repository/FuncionarioRepository.java
@@ -1,0 +1,12 @@
+package pe.gob.saip.backend.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import pe.gob.saip.backend.model.entity.Funcionario;
+
+import java.util.List;
+
+@Repository
+public interface FuncionarioRepository extends JpaRepository<Funcionario, Long> {
+    List<Funcionario> findByEntidad_IdEntidad(Long idEntidad);
+}

--- a/transparencia-backend/src/main/java/pe/gob/saip/backend/repository/MiembroTTAIPRepository.java
+++ b/transparencia-backend/src/main/java/pe/gob/saip/backend/repository/MiembroTTAIPRepository.java
@@ -1,0 +1,12 @@
+package pe.gob.saip.backend.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import pe.gob.saip.backend.model.entity.MiembroTTAIP;
+
+import java.util.List;
+
+@Repository
+public interface MiembroTTAIPRepository extends JpaRepository<MiembroTTAIP, Long> {
+    List<MiembroTTAIP> findByActivoTrue();
+}

--- a/transparencia-backend/src/main/java/pe/gob/saip/backend/repository/UsuarioRepository.java
+++ b/transparencia-backend/src/main/java/pe/gob/saip/backend/repository/UsuarioRepository.java
@@ -1,0 +1,12 @@
+package pe.gob.saip.backend.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import pe.gob.saip.backend.model.entity.Usuario;
+
+import java.util.Optional;
+
+@Repository
+public interface UsuarioRepository extends JpaRepository<Usuario, Long> {
+    Optional<Usuario> findByEmail(String email);
+}


### PR DESCRIPTION
## Contexto
Se implementa el sub-issue HU-01 BE-01 para establecer la base de persistencia de autenticacion y registro con herencia JPA de usuarios y repositorios iniciales.

## Cambios incluidos
* Se crearon las entidades base Usuario, Ciudadano, Funcionario, MiembroTTAIP, Administrador y Entidad.
* Se crearon los repositorios JPA requeridos para consultas base del sub-issue.
* Se mantuvo el alcance exclusivo en backend para BE-01.

## Trazabilidad de sub-issues
* Closes HU-01 · BE-01 · Diseñar tablas y crear entidades base #10
* Commit 32310c3 · Entidades base JPA
* Commit b323a37 · Repositorios JPA base
* Closes #10

## Validacion
* Backend: ./mvnw test -> OK
* Backend build: ./mvnw -DskipTests package -> OK

## Riesgos y mitigaciones
* Riesgo: Dependencias de relaciones hacia entidades de otros sub-issues aun no implementadas totalmente en el paquete destino.
* Mitigacion: Mantener la integracion por fases y ajustar imports/relaciones en los sub-issues siguientes sin romper BE-01.

## Checklist de revision
- [x] Validar herencia JOINED en Usuario y subclases
- [x] Validar metodos requeridos en repositorios de BE-01
- [x] Validar que el alcance del PR sea solo HU-01 BE-01
- [x] Tests y build backend en verde