### PR TITLE
🔀 feat(HU-01): BE-02 · Crear services CRUD para entidades

### DIFF
--- a/transparencia-backend/src/main/java/pe/gob/saip/backend/service/AdministradorService.java
+++ b/transparencia-backend/src/main/java/pe/gob/saip/backend/service/AdministradorService.java
@@ -1,0 +1,23 @@
+package pe.gob.saip.backend.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import pe.gob.saip.backend.model.entity.Administrador;
+import pe.gob.saip.backend.repository.AdministradorRepository;
+
+import java.util.Optional;
+
+@Service
+public class AdministradorService {
+
+    private final AdministradorRepository administradorRepository;
+
+    public AdministradorService(AdministradorRepository administradorRepository) {
+        this.administradorRepository = administradorRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<Administrador> obtenerAdministradorPorId(Long id) {
+        return administradorRepository.findById(id);
+    }
+}

--- a/transparencia-backend/src/main/java/pe/gob/saip/backend/service/CiudadanoService.java
+++ b/transparencia-backend/src/main/java/pe/gob/saip/backend/service/CiudadanoService.java
@@ -1,0 +1,33 @@
+package pe.gob.saip.backend.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import pe.gob.saip.backend.model.entity.Ciudadano;
+import pe.gob.saip.backend.repository.CiudadanoRepository;
+
+import java.util.Optional;
+
+@Service
+public class CiudadanoService {
+
+    private final CiudadanoRepository ciudadanoRepository;
+
+    public CiudadanoService(CiudadanoRepository ciudadanoRepository) {
+        this.ciudadanoRepository = ciudadanoRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<Ciudadano> obtenerCiudadanoPorDni(String dni) {
+        return ciudadanoRepository.findByDni(dni);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<Ciudadano> findById(Long id) {
+        return ciudadanoRepository.findById(id);
+    }
+
+    @Transactional
+    public Ciudadano guardarCiudadano(Ciudadano ciudadano) {
+        return ciudadanoRepository.save(ciudadano);
+    }
+}

--- a/transparencia-backend/src/main/java/pe/gob/saip/backend/service/EntidadService.java
+++ b/transparencia-backend/src/main/java/pe/gob/saip/backend/service/EntidadService.java
@@ -1,0 +1,34 @@
+package pe.gob.saip.backend.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import pe.gob.saip.backend.model.entity.Entidad;
+import pe.gob.saip.backend.repository.EntidadRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class EntidadService {
+
+    private final EntidadRepository entidadRepository;
+
+    public EntidadService(EntidadRepository entidadRepository) {
+        this.entidadRepository = entidadRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public List<Entidad> findAll() {
+        return entidadRepository.findAll();
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<Entidad> findById(Long id) {
+        return entidadRepository.findById(id);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<Entidad> findByAcronimo(String acronimo) {
+        return entidadRepository.findByAcronimo(acronimo);
+    }
+}

--- a/transparencia-backend/src/main/java/pe/gob/saip/backend/service/FuncionarioService.java
+++ b/transparencia-backend/src/main/java/pe/gob/saip/backend/service/FuncionarioService.java
@@ -1,0 +1,29 @@
+package pe.gob.saip.backend.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import pe.gob.saip.backend.model.entity.Funcionario;
+import pe.gob.saip.backend.repository.FuncionarioRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class FuncionarioService {
+
+    private final FuncionarioRepository funcionarioRepository;
+
+    public FuncionarioService(FuncionarioRepository funcionarioRepository) {
+        this.funcionarioRepository = funcionarioRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<Funcionario> obtenerFuncionarioPorId(Long id) {
+        return funcionarioRepository.findById(id);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Funcionario> obtenerFuncionariosPorEntidad(Long entidadId) {
+        return funcionarioRepository.findByEntidad_IdEntidad(entidadId);
+    }
+}

--- a/transparencia-backend/src/main/java/pe/gob/saip/backend/service/MiembroTTAIPService.java
+++ b/transparencia-backend/src/main/java/pe/gob/saip/backend/service/MiembroTTAIPService.java
@@ -1,0 +1,29 @@
+package pe.gob.saip.backend.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import pe.gob.saip.backend.model.entity.MiembroTTAIP;
+import pe.gob.saip.backend.repository.MiembroTTAIPRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class MiembroTTAIPService {
+
+    private final MiembroTTAIPRepository miembroTTAIPRepository;
+
+    public MiembroTTAIPService(MiembroTTAIPRepository miembroTTAIPRepository) {
+        this.miembroTTAIPRepository = miembroTTAIPRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<MiembroTTAIP> obtenerMiembroTTAIPPorId(Long id) {
+        return miembroTTAIPRepository.findById(id);
+    }
+
+    @Transactional(readOnly = true)
+    public List<MiembroTTAIP> obtenerMiembrosTTAIPActivos() {
+        return miembroTTAIPRepository.findByActivoTrue();
+    }
+}

--- a/transparencia-backend/src/main/java/pe/gob/saip/backend/service/UsuarioService.java
+++ b/transparencia-backend/src/main/java/pe/gob/saip/backend/service/UsuarioService.java
@@ -1,0 +1,33 @@
+package pe.gob.saip.backend.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import pe.gob.saip.backend.model.entity.Usuario;
+import pe.gob.saip.backend.repository.UsuarioRepository;
+
+import java.util.Optional;
+
+@Service
+public class UsuarioService {
+
+    private final UsuarioRepository usuarioRepository;
+
+    public UsuarioService(UsuarioRepository usuarioRepository) {
+        this.usuarioRepository = usuarioRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<Usuario> obtenerUsuarioPorEmail(String email) {
+        return usuarioRepository.findByEmail(email);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<Usuario> obtenerUsuarioPorId(Long id) {
+        return usuarioRepository.findById(id);
+    }
+
+    @Transactional
+    public Usuario guardarUsuario(Usuario usuario) {
+        return usuarioRepository.save(usuario);
+    }
+}


### PR DESCRIPTION
## Contexto
Se implementa HU-01 BE-02 para agregar la capa de servicios CRUD base de entidades de usuarios en backend, alineado al backlog SAIP.

## Cambios incluidos
* Creacion de UsuarioService
* Creacion de CiudadanoService
* Creacion de FuncionarioService
* Creacion de MiembroTTAIPService
* Creacion de AdministradorService
* Creacion de EntidadService
* Aplicacion de @Transactional(readOnly = true) en metodos de lectura

## Trazabilidad de sub-issues
* Closes HU-01 · BE-02 · Crear services CRUD para entidades #11
* Commit: 49637635947f964a9f537073afd25a52564e21f6

## Validacion
* Backend: .\\mvnw.cmd test -> OK
* Backend build: .\\mvnw.cmd -DskipTests package -> OK

## Riesgos y mitigaciones
* Riesgo: consumo de metodos no incluidos en este sub-issue por capas superiores.
* Mitigacion: alcance estricto al backlog BE-02 y ampliaciones en sub-issues posteriores.

## Checklist de revision
- [ ] Servicios creados en paquete pe.gob.saip.backend.service
- [ ] Firmas alineadas al backlog HU-01 BE-02
- [ ] Metodos de lectura con @Transactional(readOnly = true)
- [ ] Build y tests backend en verde