### PR TITLE
🔀 feat(HU-01): BE-03 · Implementar Spring Security + JWT #12

### DIFF
--- a/transparencia-backend/pom.xml
+++ b/transparencia-backend/pom.xml
@@ -98,6 +98,18 @@
             <artifactId>spring-boot-starter-webmvc-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-test-autoconfigure</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/transparencia-backend/pom.xml
+++ b/transparencia-backend/pom.xml
@@ -46,6 +46,31 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>0.12.7</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.12.7</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>0.12.7</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>2.8.6</version>

--- a/transparencia-backend/src/main/java/com/transparencia/api/security/CustomUserDetailsService.java
+++ b/transparencia-backend/src/main/java/com/transparencia/api/security/CustomUserDetailsService.java
@@ -1,0 +1,32 @@
+package com.transparencia.api.security;
+
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import com.transparencia.api.model.entity.Usuario;
+import com.transparencia.api.repository.UsuarioRepository;
+
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UsuarioRepository usuarioRepository;
+
+    public CustomUserDetailsService(UsuarioRepository usuarioRepository) {
+        this.usuarioRepository = usuarioRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        Usuario usuario = usuarioRepository.findByEmail(email)
+            .orElseThrow(() -> new UsernameNotFoundException("Usuario no encontrado: " + email));
+
+        return User.builder()
+            .username(usuario.getEmail())
+            .password(usuario.getPassword())
+            .roles(usuario.getTipoUsuario().name())
+            .disabled(!usuario.getActivo())
+            .build();
+    }
+}

--- a/transparencia-backend/src/main/java/com/transparencia/api/security/JwtAuthFilter.java
+++ b/transparencia-backend/src/main/java/com/transparencia/api/security/JwtAuthFilter.java
@@ -1,0 +1,65 @@
+package com.transparencia.api.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthFilter extends OncePerRequestFilter {
+
+    private final JwtService jwtService;
+    private final UserDetailsService userDetailsService;
+
+    public JwtAuthFilter(JwtService jwtService, UserDetailsService userDetailsService) {
+        this.jwtService = jwtService;
+        this.userDetailsService = userDetailsService;
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getServletPath();
+        return path.startsWith("/api/auth/");
+    }
+
+    @Override
+    protected void doFilterInternal(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+
+        if (header != null && header.startsWith("Bearer ")) {
+            String token = header.substring(7);
+
+            if (jwtService.isTokenValid(token)) {
+                String email = jwtService.extractEmail(token);
+
+                if (SecurityContextHolder.getContext().getAuthentication() == null) {
+                    UserDetails userDetails = userDetailsService.loadUserByUsername(email);
+                    var auth = new UsernamePasswordAuthenticationToken(
+                        userDetails,
+                        null,
+                        userDetails.getAuthorities()
+                    );
+                    auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                    SecurityContextHolder.getContext().setAuthentication(auth);
+                }
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/transparencia-backend/src/main/java/com/transparencia/api/security/JwtService.java
+++ b/transparencia-backend/src/main/java/com/transparencia/api/security/JwtService.java
@@ -1,0 +1,62 @@
+package com.transparencia.api.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Service
+public class JwtService {
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    @Value("${jwt.expiration-ms:86400000}")
+    private long expirationMs;
+
+    public String generateToken(String email, String role, Long usuarioId) {
+        return Jwts.builder()
+            .subject(email)
+            .claim("role", role)
+            .claim("usuarioId", usuarioId)
+            .issuedAt(new Date())
+            .expiration(new Date(System.currentTimeMillis() + expirationMs))
+            .signWith(getSigningKey())
+            .compact();
+    }
+
+    public String extractEmail(String token) {
+        return extractClaims(token).getSubject();
+    }
+
+    public String extractRole(String token) {
+        return extractClaims(token).get("role", String.class);
+    }
+
+    public boolean isTokenValid(String token) {
+        try {
+            extractClaims(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException ex) {
+            return false;
+        }
+    }
+
+    private Claims extractClaims(String token) {
+        return Jwts.parser()
+            .verifyWith(getSigningKey())
+            .build()
+            .parseSignedClaims(token)
+            .getPayload();
+    }
+
+    private SecretKey getSigningKey() {
+        return Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/transparencia-backend/src/main/java/com/transparencia/api/security/SecurityConfig.java
+++ b/transparencia-backend/src/main/java/com/transparencia/api/security/SecurityConfig.java
@@ -1,0 +1,77 @@
+package com.transparencia.api.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+public class SecurityConfig {
+
+    private final JwtAuthFilter jwtAuthFilter;
+
+    public SecurityConfig(JwtAuthFilter jwtAuthFilter) {
+        this.jwtAuthFilter = jwtAuthFilter;
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder(12);
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+            .csrf(csrf -> csrf.disable())
+            .headers(headers -> headers.frameOptions(frame -> frame.sameOrigin()))
+            .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/api/auth/**").permitAll()
+                .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                .requestMatchers("/h2-console/**").permitAll()
+                .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
+
+                .requestMatchers(HttpMethod.POST, "/api/solicitudes/**")
+                .hasAnyRole("CIUDADANO", "ADMINISTRADOR")
+
+                .requestMatchers(HttpMethod.POST, "/api/respuestas/**")
+                .hasAnyRole("FUNCIONARIO", "ADMINISTRADOR")
+
+                .requestMatchers("/api/ttaip/**")
+                .hasAnyRole("TTAIP", "ADMINISTRADOR")
+
+                .anyRequest().authenticated()
+            )
+            .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(List.of("http://localhost:4200"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("Authorization", "Content-Type", "Accept"));
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+}

--- a/transparencia-backend/src/main/resources/application.properties
+++ b/transparencia-backend/src/main/resources/application.properties
@@ -1,1 +1,4 @@
 spring.application.name=transparencia-backend
+jwt.secret=UnaClaveSuperSecretaQueTengaAlMenos32CaracteresParaHMACSHA256
+jwt.expiration-ms=86400000
+app.upload-dir=uploads

--- a/transparencia-backend/src/test/java/com/transparencia/api/security/CustomUserDetailsServiceTest.java
+++ b/transparencia-backend/src/test/java/com/transparencia/api/security/CustomUserDetailsServiceTest.java
@@ -1,0 +1,67 @@
+package com.transparencia.api.security;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import com.transparencia.api.model.entity.Usuario;
+import com.transparencia.api.repository.UsuarioRepository;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CustomUserDetailsServiceTest {
+
+    @Mock
+    private UsuarioRepository usuarioRepository;
+
+    @InjectMocks
+    private CustomUserDetailsService customUserDetailsService;
+
+    @Test
+    void loadUserByUsername_conUsuarioActivo_debeConstruirUserDetails() {
+        Usuario usuario = new Usuario();
+        usuario.setEmail("funcionario@saip.gob.pe");
+        usuario.setPassword("hash");
+        usuario.setTipoUsuario(Usuario.TipoUsuario.FUNCIONARIO);
+        usuario.setActivo(true);
+        when(usuarioRepository.findByEmail("funcionario@saip.gob.pe")).thenReturn(Optional.of(usuario));
+
+        UserDetails userDetails = customUserDetailsService.loadUserByUsername("funcionario@saip.gob.pe");
+
+        assertTrue(userDetails.isEnabled());
+        assertTrue(userDetails.getAuthorities().stream().anyMatch(a -> "ROLE_FUNCIONARIO".equals(a.getAuthority())));
+    }
+
+    @Test
+    void loadUserByUsername_conUsuarioInactivo_debeQuedarDeshabilitado() {
+        Usuario usuario = new Usuario();
+        usuario.setEmail("ttaip@saip.gob.pe");
+        usuario.setPassword("hash");
+        usuario.setTipoUsuario(Usuario.TipoUsuario.TTAIP);
+        usuario.setActivo(false);
+        when(usuarioRepository.findByEmail("ttaip@saip.gob.pe")).thenReturn(Optional.of(usuario));
+
+        UserDetails userDetails = customUserDetailsService.loadUserByUsername("ttaip@saip.gob.pe");
+
+        assertFalse(userDetails.isEnabled());
+    }
+
+    @Test
+    void loadUserByUsername_conUsuarioNoEncontrado_debeLanzarExcepcion() {
+        when(usuarioRepository.findByEmail("noexiste@saip.gob.pe")).thenReturn(Optional.empty());
+
+        assertThrows(
+            UsernameNotFoundException.class,
+            () -> customUserDetailsService.loadUserByUsername("noexiste@saip.gob.pe")
+        );
+    }
+}

--- a/transparencia-backend/src/test/java/com/transparencia/api/security/JwtAuthFilterTest.java
+++ b/transparencia-backend/src/test/java/com/transparencia/api/security/JwtAuthFilterTest.java
@@ -1,0 +1,84 @@
+package com.transparencia.api.security;
+
+import jakarta.servlet.FilterChain;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class JwtAuthFilterTest {
+
+    @Mock
+    private JwtService jwtService;
+
+    @Mock
+    private UserDetailsService userDetailsService;
+
+    @Mock
+    private FilterChain filterChain;
+
+    @InjectMocks
+    private JwtAuthFilter jwtAuthFilter;
+
+    @AfterEach
+    void limpiarContexto() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void shouldNotFilter_conRutaAuth_debeRetornarTrue() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setServletPath("/api/auth/login");
+
+        assertTrue(jwtAuthFilter.shouldNotFilter(request));
+    }
+
+    @Test
+    void doFilterInternal_conBearerValido_debeAutenticarUsuario() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setServletPath("/api/solicitudes");
+        request.addHeader("Authorization", "Bearer token-valido");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        when(jwtService.isTokenValid("token-valido")).thenReturn(true);
+        when(jwtService.extractEmail("token-valido")).thenReturn("ciudadano@saip.gob.pe");
+
+        UserDetails userDetails = User.builder()
+            .username("ciudadano@saip.gob.pe")
+            .password("hash")
+            .roles("CIUDADANO")
+            .build();
+        when(userDetailsService.loadUserByUsername("ciudadano@saip.gob.pe")).thenReturn(userDetails);
+
+        jwtAuthFilter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+        assertTrue(SecurityContextHolder.getContext().getAuthentication() != null);
+    }
+
+    @Test
+    void doFilterInternal_sinHeaderAuthorization_noDebeAutenticar() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setServletPath("/api/solicitudes");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        jwtAuthFilter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+        assertNull(SecurityContextHolder.getContext().getAuthentication());
+    }
+}

--- a/transparencia-backend/src/test/java/com/transparencia/api/security/JwtServiceTest.java
+++ b/transparencia-backend/src/test/java/com/transparencia/api/security/JwtServiceTest.java
@@ -1,0 +1,37 @@
+package com.transparencia.api.security;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JwtServiceTest {
+
+    private JwtService jwtService;
+
+    @BeforeEach
+    void setUp() {
+        jwtService = new JwtService();
+        ReflectionTestUtils.setField(jwtService, "secret", "UnaClaveSuperSecretaQueTengaAlMenos32CaracteresParaHMACSHA256");
+        ReflectionTestUtils.setField(jwtService, "expirationMs", 86400000L);
+    }
+
+    @Test
+    void generateToken_y_extraerClaims_debeFuncionar() {
+        String token = jwtService.generateToken("usuario@saip.gob.pe", "CIUDADANO", 15L);
+
+        assertNotNull(token);
+        assertEquals("usuario@saip.gob.pe", jwtService.extractEmail(token));
+        assertEquals("CIUDADANO", jwtService.extractRole(token));
+        assertTrue(jwtService.isTokenValid(token));
+    }
+
+    @Test
+    void isTokenValid_conTokenInvalido_debeRetornarFalse() {
+        assertFalse(jwtService.isTokenValid("token-invalido"));
+    }
+}

--- a/transparencia-backend/src/test/java/com/transparencia/api/security/SecurityConfigAuthorizationTest.java
+++ b/transparencia-backend/src/test/java/com/transparencia/api/security/SecurityConfigAuthorizationTest.java
@@ -1,0 +1,71 @@
+package com.transparencia.api.security;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class SecurityConfigAuthorizationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void rutaPublicaAuth_sinToken_noDebeSerBloqueadaPorSeguridad() throws Exception {
+        mockMvc.perform(post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"))
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void rutasProtegidas_sinToken_debenRechazarAcceso() throws Exception {
+        mockMvc.perform(get("/api/solicitudes"))
+            .andExpect(result -> {
+                int status = result.getResponse().getStatus();
+                assertTrue(status == 401 || status == 403);
+            });
+    }
+
+    @Test
+    void postSolicitudes_conRolNoPermitido_debeRetornarForbidden() throws Exception {
+        mockMvc.perform(post("/api/solicitudes")
+            .with(user("funcionario@saip.gob.pe").roles("FUNCIONARIO"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void postSolicitudes_conRolPermitido_debePasarSeguridad() throws Exception {
+        mockMvc.perform(post("/api/solicitudes")
+            .with(user("ciudadano@saip.gob.pe").roles("CIUDADANO"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void rutaTtaip_conRolNoPermitido_debeRetornarForbidden() throws Exception {
+        mockMvc.perform(get("/api/ttaip/estadisticas")
+            .with(user("funcionario@saip.gob.pe").roles("FUNCIONARIO")))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void rutaTtaip_conRolPermitido_debePasarSeguridad() throws Exception {
+        mockMvc.perform(get("/api/ttaip/estadisticas")
+            .with(user("miembro@saip.gob.pe").roles("TTAIP")))
+            .andExpect(status().isNotFound());
+    }
+}


### PR DESCRIPTION
## Contexto
Se implementa HU-01 BE-03 para habilitar autenticacion JWT y seguridad stateless en backend.
La implementacion y pruebas se realizaron en el namespace de transparencia com.transparencia.api, sin cambios de seguridad en pe.gob.saip.backend.

## Cambios incluidos
* JwtService, CustomUserDetailsService, JwtAuthFilter y SecurityConfig
* Configuracion JWT en application.properties
* Dependencias de seguridad en pom.xml
* Pruebas unitarias de JWT y Security
* Pruebas de autorizacion por endpoint

## Trazabilidad de sub-issues
* Closes #12
* HU-01 ┬À BE-03 ┬À Implementar Spring Security + JWT
* Commits:
  - 1555324534503fadfc72523653c495aff704f962
  - 2111298d53447acdb4923f1aefa814bbce2d06be
  - 4758fc6a857e39e907aa597a483327bc016cb63c

## Validacion
* Backend: .\\mvnw.cmd test -> OK
* Backend build: .\\mvnw.cmd -DskipTests package -> OK

## Riesgos y mitigaciones
* Riesgo: reglas de autorizacion iniciales pueden requerir ajuste al crecer endpoints.
* Mitigacion: reglas centralizadas en SecurityConfig y cubiertas por pruebas.

## Checklist de revision
- [x] JWT implementado y validado
- [x] Filtro JWT activo y rutas publicas definidas
- [x] Reglas por rol para solicitudes/respuestas/ttaip
- [x] Alcance BE-03 en com.transparencia.api
- [x] Build y tests backend en verde
