### PR TITLE
✨ feat(HU-07): FE-02 · TtaipSegundaCalificacionComponent

### DIFF
--- a/transparencia-frontend/src/app/app.routes.ts
+++ b/transparencia-frontend/src/app/app.routes.ts
@@ -1,5 +1,4 @@
 import { Routes } from '@angular/router';
-
 export const routes: Routes = [
   {
     path: 'ttaip',

--- a/transparencia-frontend/src/app/app.spec.ts
+++ b/transparencia-frontend/src/app/app.spec.ts
@@ -13,5 +13,4 @@ describe('App', () => {
     const app = fixture.componentInstance;
     expect(app).toBeTruthy();
   });
-
 });

--- a/transparencia-frontend/src/app/pages/ttaip/ttaip-segunda-calificacion.component.html
+++ b/transparencia-frontend/src/app/pages/ttaip/ttaip-segunda-calificacion.component.html
@@ -1,7 +1,7 @@
 <div class="min-h-screen bg-[#f6f8fb] text-[#1f2937]">
   <div class="border-b border-[#e5e7eb] bg-[#f3f6fa] px-4 pt-24 pb-10">
     <div class="mx-auto max-w-6xl">
-      <a [routerLink]="['/']" class="mb-4 flex items-center gap-2 w-fit text-sm text-[#6b7280] transition hover:text-[#111827] cursor-pointer no-underline">
+      <a [routerLink]="['/']" class="mb-4 flex items-center gap-2 w-fit text-sm text-[#6b7280] transition hover:text-[#111827] cursor-pointer" style="text-decoration: none;">
         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m12 19-7-7 7-7"/><path d="M19 12H5"/></svg>
         Volver al Panel Base
       </a>
@@ -67,6 +67,9 @@
                           <p class="text-xs text-[#6b7280] m-0">Presentado el 10/09/2025 - 450 KB</p>
                         </div>
                       </div>
+                      <button type="button" class="rounded-lg p-2 text-[#374151] transition hover:bg-white border-0 bg-transparent cursor-pointer">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg>
+                      </button>
                     </div>
                   </div>
                   <div class="rounded-xl border border-[#d1fae5] bg-[#ecfdf5] p-4">
@@ -78,9 +81,31 @@
                           <p class="text-xs text-[#6b7280] m-0">Presentado el 10/09/2025 - 320 KB</p>
                         </div>
                       </div>
+                      <button type="button" class="rounded-lg p-2 text-[#374151] transition hover:bg-white border-0 bg-transparent cursor-pointer">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg>
+                      </button>
+                    </div>
+                  </div>
+                  <div class="rounded-xl border border-[#d1fae5] bg-[#ecfdf5] p-4">
+                    <div class="flex items-center justify-between gap-3">
+                      <div class="flex items-center gap-3">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-[#16a34a]"><circle cx="12" cy="12" r="10"/><path d="m9 12 2 2 4-4"/></svg>
+                        <div>
+                          <p class="text-sm font-semibold text-[#1f2937] m-0">Declaracion_Domicilio.pdf</p>
+                          <p class="text-xs text-[#6b7280] m-0">Presentado el 10/09/2025 - 180 KB</p>
+                        </div>
+                      </div>
+                      <button type="button" class="rounded-lg p-2 text-[#374151] transition hover:bg-white border-0 bg-transparent cursor-pointer">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg>
+                      </button>
                     </div>
                   </div>
                 </div>
+              </div>
+
+              <div class="rounded-lg bg-[#f3f4f6] p-3 text-xs text-[#6b7280]">
+                <p class="m-0"><strong>Fecha limite de subsanacion:</strong> 11/09/2025</p>
+                <p class="mt-1 m-0"><strong>Fecha de presentacion:</strong> 10/09/2025 (dentro del plazo)</p>
               </div>
             </div>
           </div>
@@ -92,8 +117,30 @@
             <div class="space-y-3 px-6 py-5">
               <div class="flex items-center justify-between rounded-xl border border-[#e5e7eb] p-4 transition hover:bg-[#f8fafc]">
                 <div class="flex items-center gap-3">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-[#334155]"><path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"/><polyline points="14 2 14 8 20 8"/><line x1="16" x2="8" y1="13" y2="13"/><line x1="16" x2="8" y1="17" y2="17"/><line x1="10" x2="8" y1="9" y2="9"/></svg>
                   <span class="text-sm text-[#1f2937]">Apelacion_Original.pdf</span>
                 </div>
+                <button type="button" class="rounded-lg p-2 text-[#374151] transition hover:bg-[#f1f5f9] border-0 bg-transparent cursor-pointer">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg>
+                </button>
+              </div>
+              <div class="flex items-center justify-between rounded-xl border border-[#e5e7eb] p-4 transition hover:bg-[#f8fafc]">
+                <div class="flex items-center gap-3">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-[#334155]"><path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"/><polyline points="14 2 14 8 20 8"/><line x1="16" x2="8" y1="13" y2="13"/><line x1="16" x2="8" y1="17" y2="17"/><line x1="10" x2="8" y1="9" y2="9"/></svg>
+                  <span class="text-sm text-[#1f2937]">1ra_Calificacion_Inadmisible.pdf</span>
+                </div>
+                <button type="button" class="rounded-lg p-2 text-[#374151] transition hover:bg-[#f1f5f9] border-0 bg-transparent cursor-pointer">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg>
+                </button>
+              </div>
+              <div class="flex items-center justify-between rounded-xl border border-[#e5e7eb] p-4 transition hover:bg-[#f8fafc]">
+                <div class="flex items-center gap-3">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-[#334155]"><path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"/><polyline points="14 2 14 8 20 8"/><line x1="16" x2="8" y1="13" y2="13"/><line x1="16" x2="8" y1="17" y2="17"/><line x1="10" x2="8" y1="9" y2="9"/></svg>
+                  <span class="text-sm text-[#1f2937]">Notificacion_Subsanacion.pdf</span>
+                </div>
+                <button type="button" class="rounded-lg p-2 text-[#374151] transition hover:bg-[#f1f5f9] border-0 bg-transparent cursor-pointer">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg>
+                </button>
               </div>
             </div>
           </div>
@@ -136,6 +183,34 @@
           </div>
         </div>
 
+        @if (decision === 'admitido') {
+          <div class="rounded-2xl border border-[#10b981] bg-[#f0fdf4] p-4">
+            <div class="flex items-start gap-3">
+              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="mt-0.5 text-[#10b981]"><circle cx="12" cy="12" r="10"/><path d="m9 12 2 2 4-4"/></svg>
+              <div>
+                <p class="font-semibold text-[#065f46] m-0">Admitido a Tramite</p>
+                <p class="mt-1 text-sm text-[#065f46] m-0">
+                  La subsanacion cumple con todos los requisitos. El expediente pasara a la etapa de Resolucion Final donde se emitira un fallo de Fundado o Infundado.
+                </p>
+              </div>
+            </div>
+          </div>
+        }
+
+        @if (decision === 'improcedente') {
+          <div class="rounded-2xl border border-[#9ca3af] bg-[#f3f4f6] p-4">
+            <div class="flex items-start gap-3">
+              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="mt-0.5 text-[#6b7280]"><circle cx="12" cy="12" r="10"/><path d="m15 9-6 6"/><path d="m9 9 6 6"/></svg>
+              <div>
+                <p class="font-semibold text-[#374151] m-0">Apelacion Improcedente</p>
+                <p class="mt-1 text-sm text-[#374151] m-0">
+                  La subsanacion presentada no cumple con los requisitos establecidos. El proceso se archiva y no continua a siguientes etapas.
+                </p>
+              </div>
+            </div>
+          </div>
+        }
+
         <div class="overflow-hidden rounded-2xl border border-[#e5e7eb] bg-white shadow-sm">
           <div class="border-b border-[#e5e7eb] px-6 py-5">
             <h2 class="text-[15px] font-medium m-0">Fundamentos de la Verificacion</h2>
@@ -144,11 +219,50 @@
             <label for="fundamentos" class="mb-2 block text-sm font-medium text-[#111827]">
               Fundamentos <span class="text-red-600">*</span>
             </label>
-            <textarea id="fundamentos" rows="5" [(ngModel)]="fundamentos" placeholder="Describa el analisis de la subsanacion..." class="w-full rounded-xl border border-[#d1d5db] bg-white px-4 py-3 text-sm outline-none transition focus:border-[#A72525] focus:ring-1 focus:ring-[#A72525] box-border"></textarea>
+            <textarea id="fundamentos" rows="5" [(ngModel)]="fundamentos" placeholder="Describa el analisis de la subsanacion y los fundamentos de la decision..." class="w-full rounded-xl border border-[#d1d5db] bg-white px-4 py-3 text-sm outline-none transition focus:border-[#94a3b8] box-border"></textarea>
+            <p class="mt-2 text-xs text-[#6b7280] m-0">{{ fundamentos.length }} caracteres</p>
           </div>
         </div>
 
-        <button type="button" (click)="handleEmitir()" [disabled]="!decision || !fundamentos.trim()" class="flex w-full items-center justify-center gap-2 rounded-xl bg-[#A72525] px-4 py-4 text-sm font-medium text-white shadow-md transition hover:bg-[#851c1c] disabled:cursor-not-allowed disabled:bg-gray-400 border-0 cursor-pointer">
+        <button type="button" (click)="showPreview = !showPreview" class="flex w-full items-center justify-center gap-2 rounded-xl border border-[#d1d5db] bg-white px-4 py-3 text-sm font-medium text-[#374151] transition hover:bg-[#f9fafb] cursor-pointer">
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"/><polyline points="14 2 14 8 20 8"/><line x1="16" x2="8" y1="13" y2="13"/><line x1="16" x2="8" y1="17" y2="17"/><line x1="10" x2="8" y1="9" y2="9"/></svg>
+          {{ showPreview ? 'Ocultar' : 'Previsualizar' }} PDF de 2da Calificacion
+        </button>
+
+        @if (showPreview) {
+          <div class="rounded-2xl border border-[#e5e7eb] bg-white p-6 shadow-sm">
+            <div class="text-center">
+              <h3 class="text-lg font-bold m-0">TRIBUNAL DE TRANSPARENCIA Y ACCESO A LA INFORMACION PUBLICA</h3>
+              <h4 class="mt-2 font-semibold m-0">2DA CALIFICACION N° {{ expediente }}-C2</h4>
+            </div>
+            <div class="mt-6 space-y-4 text-sm leading-6 text-[#111827]">
+              <div>
+                <p class="font-bold m-0">EXPEDIENTE:</p>
+                <p class="m-0">{{ expediente }}</p>
+              </div>
+              <div>
+                <p class="font-bold m-0">VISTOS:</p>
+                <p class="m-0">La subsanacion presentada por el administrado dentro del plazo otorgado.</p>
+              </div>
+              <div>
+                <p class="font-bold m-0">CONSIDERANDOS:</p>
+                <p class="m-0">{{ fundamentos || '[Fundamentos de la verificacion...]' }}</p>
+              </div>
+              <div>
+                <p class="font-bold m-0">SE RESUELVE:</p>
+                <p class="m-0">Declarar <strong>{{ decision ? decision.toUpperCase() : '[DECISION]' }}</strong> el recurso de apelacion.</p>
+                @if (decision === 'admitido') {
+                  <p class="mt-2 m-0">La subsanacion presentada cumple con los requisitos. El expediente pasa a la etapa de Resolucion Final.</p>
+                }
+                @if (decision === 'improcedente') {
+                  <p class="mt-2 m-0">Archivese el expediente por no cumplir con los requisitos legales establecidos tras la subsanacion.</p>
+                }
+              </div>
+            </div>
+          </div>
+        }
+
+        <button type="button" (click)="handleEmitir()" [disabled]="!decision || !fundamentos.trim()" class="flex w-full items-center justify-center gap-2 rounded-xl bg-[#6b7280] px-4 py-4 text-sm font-medium text-white shadow-md transition hover:bg-[#4b5563] disabled:cursor-not-allowed disabled:opacity-50 border-0 cursor-pointer">
           <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="22" x2="11" y1="2" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>
           Emitir 2da Calificacion
         </button>

--- a/transparencia-frontend/src/app/pages/ttaip/ttaip-segunda-calificacion.component.html
+++ b/transparencia-frontend/src/app/pages/ttaip/ttaip-segunda-calificacion.component.html
@@ -1,9 +1,9 @@
 <div class="min-h-screen bg-[#f6f8fb] text-[#1f2937]">
   <div class="border-b border-[#e5e7eb] bg-[#f3f6fa] px-4 pt-24 pb-10">
     <div class="mx-auto max-w-6xl">
-      <a [routerLink]="['/ttaip']" class="mb-4 flex items-center gap-2 w-fit text-sm text-[#6b7280] transition hover:text-[#111827] cursor-pointer" style="text-decoration: none;">
+      <a [routerLink]="['/']" class="mb-4 flex items-center gap-2 w-fit text-sm text-[#6b7280] transition hover:text-[#111827] cursor-pointer no-underline">
         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m12 19-7-7 7-7"/><path d="M19 12H5"/></svg>
-        Volver al Panel TTAIP
+        Volver al Panel Base
       </a>
 
       <h1 class="text-4xl font-medium tracking-tight text-[#111827] m-0">
@@ -67,9 +67,6 @@
                           <p class="text-xs text-[#6b7280] m-0">Presentado el 10/09/2025 - 450 KB</p>
                         </div>
                       </div>
-                      <button type="button" class="rounded-lg p-2 text-[#374151] transition hover:bg-white border-0 bg-transparent cursor-pointer">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg>
-                      </button>
                     </div>
                   </div>
                   <div class="rounded-xl border border-[#d1fae5] bg-[#ecfdf5] p-4">
@@ -81,31 +78,9 @@
                           <p class="text-xs text-[#6b7280] m-0">Presentado el 10/09/2025 - 320 KB</p>
                         </div>
                       </div>
-                      <button type="button" class="rounded-lg p-2 text-[#374151] transition hover:bg-white border-0 bg-transparent cursor-pointer">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg>
-                      </button>
-                    </div>
-                  </div>
-                  <div class="rounded-xl border border-[#d1fae5] bg-[#ecfdf5] p-4">
-                    <div class="flex items-center justify-between gap-3">
-                      <div class="flex items-center gap-3">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-[#16a34a]"><circle cx="12" cy="12" r="10"/><path d="m9 12 2 2 4-4"/></svg>
-                        <div>
-                          <p class="text-sm font-semibold text-[#1f2937] m-0">Declaracion_Domicilio.pdf</p>
-                          <p class="text-xs text-[#6b7280] m-0">Presentado el 10/09/2025 - 180 KB</p>
-                        </div>
-                      </div>
-                      <button type="button" class="rounded-lg p-2 text-[#374151] transition hover:bg-white border-0 bg-transparent cursor-pointer">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg>
-                      </button>
                     </div>
                   </div>
                 </div>
-              </div>
-
-              <div class="rounded-lg bg-[#f3f4f6] p-3 text-xs text-[#6b7280]">
-                <p class="m-0"><strong>Fecha limite de subsanacion:</strong> 11/09/2025</p>
-                <p class="mt-1 m-0"><strong>Fecha de presentacion:</strong> 10/09/2025 (dentro del plazo)</p>
               </div>
             </div>
           </div>
@@ -117,30 +92,8 @@
             <div class="space-y-3 px-6 py-5">
               <div class="flex items-center justify-between rounded-xl border border-[#e5e7eb] p-4 transition hover:bg-[#f8fafc]">
                 <div class="flex items-center gap-3">
-                  <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-[#334155]"><path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"/><polyline points="14 2 14 8 20 8"/><line x1="16" x2="8" y1="13" y2="13"/><line x1="16" x2="8" y1="17" y2="17"/><line x1="10" x2="8" y1="9" y2="9"/></svg>
                   <span class="text-sm text-[#1f2937]">Apelacion_Original.pdf</span>
                 </div>
-                <button type="button" class="rounded-lg p-2 text-[#374151] transition hover:bg-[#f1f5f9] border-0 bg-transparent cursor-pointer">
-                  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg>
-                </button>
-              </div>
-              <div class="flex items-center justify-between rounded-xl border border-[#e5e7eb] p-4 transition hover:bg-[#f8fafc]">
-                <div class="flex items-center gap-3">
-                  <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-[#334155]"><path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"/><polyline points="14 2 14 8 20 8"/><line x1="16" x2="8" y1="13" y2="13"/><line x1="16" x2="8" y1="17" y2="17"/><line x1="10" x2="8" y1="9" y2="9"/></svg>
-                  <span class="text-sm text-[#1f2937]">1ra_Calificacion_Inadmisible.pdf</span>
-                </div>
-                <button type="button" class="rounded-lg p-2 text-[#374151] transition hover:bg-[#f1f5f9] border-0 bg-transparent cursor-pointer">
-                  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg>
-                </button>
-              </div>
-              <div class="flex items-center justify-between rounded-xl border border-[#e5e7eb] p-4 transition hover:bg-[#f8fafc]">
-                <div class="flex items-center gap-3">
-                  <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-[#334155]"><path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"/><polyline points="14 2 14 8 20 8"/><line x1="16" x2="8" y1="13" y2="13"/><line x1="16" x2="8" y1="17" y2="17"/><line x1="10" x2="8" y1="9" y2="9"/></svg>
-                  <span class="text-sm text-[#1f2937]">Notificacion_Subsanacion.pdf</span>
-                </div>
-                <button type="button" class="rounded-lg p-2 text-[#374151] transition hover:bg-[#f1f5f9] border-0 bg-transparent cursor-pointer">
-                  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg>
-                </button>
               </div>
             </div>
           </div>
@@ -183,34 +136,6 @@
           </div>
         </div>
 
-        @if (decision === 'admitido') {
-          <div class="rounded-2xl border border-[#10b981] bg-[#f0fdf4] p-4">
-            <div class="flex items-start gap-3">
-              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="mt-0.5 text-[#10b981]"><circle cx="12" cy="12" r="10"/><path d="m9 12 2 2 4-4"/></svg>
-              <div>
-                <p class="font-semibold text-[#065f46] m-0">Admitido a Tramite</p>
-                <p class="mt-1 text-sm text-[#065f46] m-0">
-                  La subsanacion cumple con todos los requisitos. El expediente pasara a la etapa de Resolucion Final donde se emitira un fallo de Fundado o Infundado.
-                </p>
-              </div>
-            </div>
-          </div>
-        }
-
-        @if (decision === 'improcedente') {
-          <div class="rounded-2xl border border-[#9ca3af] bg-[#f3f4f6] p-4">
-            <div class="flex items-start gap-3">
-              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="mt-0.5 text-[#6b7280]"><circle cx="12" cy="12" r="10"/><path d="m15 9-6 6"/><path d="m9 9 6 6"/></svg>
-              <div>
-                <p class="font-semibold text-[#374151] m-0">Apelacion Improcedente</p>
-                <p class="mt-1 text-sm text-[#374151] m-0">
-                  La subsanacion presentada no cumple con los requisitos establecidos. El proceso se archiva y no continua a siguientes etapas.
-                </p>
-              </div>
-            </div>
-          </div>
-        }
-
         <div class="overflow-hidden rounded-2xl border border-[#e5e7eb] bg-white shadow-sm">
           <div class="border-b border-[#e5e7eb] px-6 py-5">
             <h2 class="text-[15px] font-medium m-0">Fundamentos de la Verificacion</h2>
@@ -219,50 +144,11 @@
             <label for="fundamentos" class="mb-2 block text-sm font-medium text-[#111827]">
               Fundamentos <span class="text-red-600">*</span>
             </label>
-            <textarea id="fundamentos" rows="5" [(ngModel)]="fundamentos" placeholder="Describa el analisis de la subsanacion y los fundamentos de la decision..." class="w-full rounded-xl border border-[#d1d5db] bg-white px-4 py-3 text-sm outline-none transition focus:border-[#94a3b8] box-border"></textarea>
-            <p class="mt-2 text-xs text-[#6b7280] m-0">{{ fundamentos.length }} caracteres</p>
+            <textarea id="fundamentos" rows="5" [(ngModel)]="fundamentos" placeholder="Describa el analisis de la subsanacion..." class="w-full rounded-xl border border-[#d1d5db] bg-white px-4 py-3 text-sm outline-none transition focus:border-[#A72525] focus:ring-1 focus:ring-[#A72525] box-border"></textarea>
           </div>
         </div>
 
-        <button type="button" (click)="showPreview = !showPreview" class="flex w-full items-center justify-center gap-2 rounded-xl border border-[#d1d5db] bg-white px-4 py-3 text-sm font-medium text-[#374151] transition hover:bg-[#f9fafb] cursor-pointer">
-          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"/><polyline points="14 2 14 8 20 8"/><line x1="16" x2="8" y1="13" y2="13"/><line x1="16" x2="8" y1="17" y2="17"/><line x1="10" x2="8" y1="9" y2="9"/></svg>
-          {{ showPreview ? 'Ocultar' : 'Previsualizar' }} PDF de 2da Calificacion
-        </button>
-
-        @if (showPreview) {
-          <div class="rounded-2xl border border-[#e5e7eb] bg-white p-6 shadow-sm">
-            <div class="text-center">
-              <h3 class="text-lg font-bold m-0">TRIBUNAL DE TRANSPARENCIA Y ACCESO A LA INFORMACION PUBLICA</h3>
-              <h4 class="mt-2 font-semibold m-0">2DA CALIFICACION N° {{ expediente }}-C2</h4>
-            </div>
-            <div class="mt-6 space-y-4 text-sm leading-6 text-[#111827]">
-              <div>
-                <p class="font-bold m-0">EXPEDIENTE:</p>
-                <p class="m-0">{{ expediente }}</p>
-              </div>
-              <div>
-                <p class="font-bold m-0">VISTOS:</p>
-                <p class="m-0">La subsanacion presentada por el administrado dentro del plazo otorgado.</p>
-              </div>
-              <div>
-                <p class="font-bold m-0">CONSIDERANDOS:</p>
-                <p class="m-0">{{ fundamentos || '[Fundamentos de la verificacion...]' }}</p>
-              </div>
-              <div>
-                <p class="font-bold m-0">SE RESUELVE:</p>
-                <p class="m-0">Declarar <strong>{{ decision ? decision.toUpperCase() : '[DECISION]' }}</strong> el recurso de apelacion.</p>
-                @if (decision === 'admitido') {
-                  <p class="mt-2 m-0">La subsanacion presentada cumple con los requisitos. El expediente pasa a la etapa de Resolucion Final.</p>
-                }
-                @if (decision === 'improcedente') {
-                  <p class="mt-2 m-0">Archivese el expediente por no cumplir con los requisitos legales establecidos tras la subsanacion.</p>
-                }
-              </div>
-            </div>
-          </div>
-        }
-
-        <button type="button" (click)="handleEmitir()" [disabled]="!decision || !fundamentos.trim()" class="flex w-full items-center justify-center gap-2 rounded-xl bg-[#6b7280] px-4 py-4 text-sm font-medium text-white shadow-md transition hover:bg-[#4b5563] disabled:cursor-not-allowed disabled:opacity-50 border-0 cursor-pointer">
+        <button type="button" (click)="handleEmitir()" [disabled]="!decision || !fundamentos.trim()" class="flex w-full items-center justify-center gap-2 rounded-xl bg-[#A72525] px-4 py-4 text-sm font-medium text-white shadow-md transition hover:bg-[#851c1c] disabled:cursor-not-allowed disabled:bg-gray-400 border-0 cursor-pointer">
           <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="22" x2="11" y1="2" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>
           Emitir 2da Calificacion
         </button>


### PR DESCRIPTION
## Descripción
Se implementa la interfaz de alta fidelidad para el componente de Segunda Calificación (`TtaipSegundaCalificacionComponent`), desarrollando el diseño de Figma a Angular.

### Características implementadas:
- **Maquetación a dos columnas:** Visualización de documentos adjuntos a la izquierda y formulario de resolución a la derecha.
- **Lógica de validación:** El botón de emisión se mantiene deshabilitado hasta que se seleccione una decisión y se redacten los fundamentos.
- **Identidad institucional:** Se integró el color guindo principal (#A72525) para el botón de acción "Emitir 2da Calificación", manteniendo la línea gráfica del TTAIP.
- **Selección de estado:** Botones interactivos para marcar el caso como "ADMITIDO A TRÁMITE" o "IMPROCEDENTE".

Forma parte de la HU-07.
This pull request introduces two new pages to the application for managing TTAIP (Tribunal de Transparencia y Acceso a la Información Pública) appeals: a dashboard and a detailed "Segunda Calificación" (Second Review) workflow. It also configures routing to access these pages and provides UI and logic for filtering, reviewing, and issuing second-stage appeal decisions.

**New TTAIP Appeals Management Features:**

*Routing and Navigation*
- Added routes for the TTAIP dashboard (`/ttaip`) and the second review page (`/ttaip/segunda-calificacion/:expediente`), with a default redirect to the dashboard. (`app.routes.ts`)

*Dashboard Page*
- Implemented `TtaipDashboardComponent` with a table listing appeals, filter buttons to view all or only "subsanadas" (remediated) appeals, and navigation to the second review page for eligible cases. (`ttaip-dashboard.component.ts`, `ttaip-dashboard.component.html`) [[1]](diffhunk://#diff-f2fdc29b32ac7beb7920d1569ebfd65c3ccd9540e07b3480d81a80a4cc1716aaR1-R28) [[2]](diffhunk://#diff-2d8c325c2aaebdc447e8cbfec77d712eca6758850ace9ab4be057038d9ba71c4R1-R41)

*Second Review Workflow*
- Added `TtaipSegundaCalificacionComponent` to display details of an appeal's second review, including tabs for "Subsanacion" and "Adjuntos", a list of review documents, and previous observations. (`ttaip-segunda-calificacion.component.ts`, `ttaip-segunda-calificacion.component.html`) [[1]](diffhunk://#diff-087cc33a316cabda2d39894ce118bc18993eb4a85c11c1d9ee333e73a804f4d5R1-R32) [[2]](diffhunk://#diff-bb54ddb34067728b5864ca3f01b422f9784e52e239f0ed9a1cb9fe6fd86acf33R1-R272)
- Provided UI for selecting the review outcome (Admitido a Trámite or Improcedente), entering justification, and previewing a formatted PDF-like summary of the decision before emitting it.
- Added form validation and feedback for required fields before issuing the decision.

These changes lay the groundwork for a structured TTAIP appeal review process, with clear navigation, filtering, and decision support for tribunal staff.