### PR TITLE
🔀 test(HU-01): BE-05 · Pruebas unitarias AuthRestControllerTest

### DIFF
--- a/transparencia-backend/src/main/java/com/transparencia/api/controller/AuthRestController.java
+++ b/transparencia-backend/src/main/java/com/transparencia/api/controller/AuthRestController.java
@@ -1,0 +1,242 @@
+package com.transparencia.api.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import com.transparencia.api.exception.RecursoNoEncontradoException;
+import com.transparencia.api.model.dto.LoginRequestDTO;
+import com.transparencia.api.model.dto.RegistroRequestDTO;
+import com.transparencia.api.model.entity.Ciudadano;
+import com.transparencia.api.model.entity.Usuario;
+import com.transparencia.api.security.JwtService;
+import com.transparencia.api.service.AdministradorService;
+import com.transparencia.api.service.CiudadanoService;
+import com.transparencia.api.service.FuncionarioService;
+import com.transparencia.api.service.MiembroTTAIPService;
+import com.transparencia.api.service.UsuarioService;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/auth")
+@Tag(name = "Autenticacion", description = "Registro de ciudadanos y login con JWT")
+public class AuthRestController {
+
+    private final UsuarioService usuarioService;
+    private final CiudadanoService ciudadanoService;
+    private final FuncionarioService funcionarioService;
+    private final MiembroTTAIPService miembroTTAIPService;
+    private final AdministradorService administradorService;
+    private final JwtService jwtService;
+    private final PasswordEncoder passwordEncoder;
+
+    public AuthRestController(
+        UsuarioService usuarioService,
+        CiudadanoService ciudadanoService,
+        FuncionarioService funcionarioService,
+        MiembroTTAIPService miembroTTAIPService,
+        AdministradorService administradorService,
+        JwtService jwtService,
+        PasswordEncoder passwordEncoder
+    ) {
+        this.usuarioService = usuarioService;
+        this.ciudadanoService = ciudadanoService;
+        this.funcionarioService = funcionarioService;
+        this.miembroTTAIPService = miembroTTAIPService;
+        this.administradorService = administradorService;
+        this.jwtService = jwtService;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @Operation(summary = "Iniciar sesion", description = "Autentica al usuario y retorna JWT con datos de perfil")
+    @PostMapping("/login")
+    public ResponseEntity<Map<String, Object>> login(@Valid @RequestBody LoginRequestDTO request) {
+        Optional<Usuario> usuarioOpt = resolverUsuario(request.identificador().trim());
+
+        if (usuarioOpt.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of(
+                "success", false,
+                "mensaje", "Usuario no encontrado"
+            ));
+        }
+
+        Usuario usuario = usuarioOpt.get();
+
+        if (!verificarPassword(request.password(), usuario)) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of(
+                "success", false,
+                "mensaje", "Contrasena incorrecta"
+            ));
+        }
+
+        if (!Boolean.TRUE.equals(usuario.getActivo())) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of(
+                "success", false,
+                "mensaje", "Usuario desactivado"
+            ));
+        }
+
+        String token = jwtService.generateToken(
+            usuario.getEmail(),
+            usuario.getTipoUsuario().name(),
+            usuario.getIdUsuario()
+        );
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("success", true);
+        response.put("token", token);
+        response.put("usuarioId", usuario.getIdUsuario());
+        response.put("email", usuario.getEmail());
+        response.put("tipoUsuario", usuario.getTipoUsuario().name());
+
+        switch (usuario.getTipoUsuario()) {
+            case CIUDADANO -> {
+                ciudadanoService.findById(usuario.getIdUsuario()).ifPresent(ciudadano -> {
+                    response.put("nombre", ciudadano.getNombreCompleto());
+                    response.put("dni", ciudadano.getDni());
+                    response.put("ciudadanoId", ciudadano.getId());
+                });
+                response.put("redirectUrl", "/ciudadano/dashboard");
+            }
+            case FUNCIONARIO -> {
+                funcionarioService.obtenerFuncionarioPorId(usuario.getIdUsuario()).ifPresent(funcionario -> {
+                    response.put("nombre", funcionario.getNombreCompleto());
+                    response.put("cargo", funcionario.getCargo());
+                    response.put("funcionarioId", funcionario.getId());
+
+                    if (funcionario.getEntidad() != null) {
+                        response.put("entidadId", funcionario.getEntidad().getId());
+                        response.put("entidadNombre", funcionario.getEntidad().getNombre());
+                    }
+                });
+                response.put("redirectUrl", "/entidad/dashboard");
+            }
+            case TTAIP -> {
+                miembroTTAIPService.obtenerMiembroTTAIPPorId(usuario.getIdUsuario()).ifPresent(miembro -> {
+                    response.put("nombre", miembro.getNombreCompleto());
+                    response.put("cargo", miembro.getCargo());
+                    response.put("miembroId", miembro.getIdUsuario());
+                });
+                response.put("redirectUrl", "/ttaip/dashboard");
+            }
+            case ADMINISTRADOR -> {
+                administradorService.obtenerAdministradorPorId(usuario.getIdUsuario()).ifPresent(administrador -> {
+                    response.put("nombre", administrador.getNombreCompleto());
+                    response.put("administradorId", administrador.getId());
+                });
+                response.put("redirectUrl", "/admin/dashboard");
+            }
+        }
+
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "Registrar ciudadano", description = "Registra un ciudadano con email, password y DNI")
+    @PostMapping("/registro")
+    public ResponseEntity<Map<String, Object>> registro(@Valid @RequestBody RegistroRequestDTO request) {
+        if (usuarioService.obtenerUsuarioPorEmail(request.email()).isPresent()) {
+            return ResponseEntity.badRequest().body(Map.of(
+                "success", false,
+                "mensaje", "Ya existe un usuario con ese email"
+            ));
+        }
+
+        if (ciudadanoService.obtenerCiudadanoPorDni(request.dni()).isPresent()) {
+            return ResponseEntity.badRequest().body(Map.of(
+                "success", false,
+                "mensaje", "Ya existe un ciudadano con ese DNI"
+            ));
+        }
+
+        Ciudadano ciudadano = new Ciudadano();
+        ciudadano.setEmail(request.email().trim());
+        ciudadano.setPassword(passwordEncoder.encode(request.password()));
+        ciudadano.setTipoUsuario(Usuario.TipoUsuario.CIUDADANO);
+        ciudadano.setActivo(true);
+        ciudadano.setDni(request.dni());
+        ciudadano.setNombreCompleto(request.nombreCompleto().trim());
+        ciudadano.setTelefono(request.telefono());
+        ciudadano.setDireccion(request.direccion());
+
+        ciudadano = ciudadanoService.guardarCiudadano(ciudadano);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(Map.of(
+            "success", true,
+            "mensaje", "Registro exitoso",
+            "ciudadanoId", ciudadano.getId(),
+            "email", ciudadano.getEmail()
+        ));
+    }
+
+    @Operation(summary = "Verificar disponibilidad de email")
+    @GetMapping("/verificar-email")
+    public ResponseEntity<Map<String, Object>> verificarEmail(@RequestParam String email) {
+        boolean existe = usuarioService.obtenerUsuarioPorEmail(email).isPresent();
+        return ResponseEntity.ok(Map.of("existe", existe));
+    }
+
+    @Operation(summary = "Verificar disponibilidad de DNI")
+    @GetMapping("/verificar-dni")
+    public ResponseEntity<Map<String, Object>> verificarDni(@RequestParam String dni) {
+        boolean existe = ciudadanoService.obtenerCiudadanoPorDni(dni).isPresent();
+        return ResponseEntity.ok(Map.of("existe", existe));
+    }
+
+    @Operation(summary = "Obtener usuario", description = "Retorna datos basicos del usuario por usuarioId")
+    @GetMapping("/me/{usuarioId}")
+    public ResponseEntity<Map<String, Object>> obtenerUsuarioActual(@PathVariable Long usuarioId) {
+        Usuario usuario = usuarioService.obtenerUsuarioPorId(usuarioId)
+            .orElseThrow(() -> new RecursoNoEncontradoException("Usuario no encontrado con ID: " + usuarioId));
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("usuarioId", usuario.getIdUsuario());
+        response.put("email", usuario.getEmail());
+        response.put("tipoUsuario", usuario.getTipoUsuario().name());
+        response.put("activo", usuario.getActivo());
+
+        return ResponseEntity.ok(response);
+    }
+
+    private Optional<Usuario> resolverUsuario(String identificador) {
+        if (identificador.contains("@")) {
+            return usuarioService.obtenerUsuarioPorEmail(identificador);
+        }
+
+        if (identificador.matches("\\d{8}")) {
+            return ciudadanoService.obtenerCiudadanoPorDni(identificador).map(ciudadano -> (Usuario) ciudadano);
+        }
+
+        return usuarioService.obtenerUsuarioPorEmail(identificador);
+    }
+
+    private boolean verificarPassword(String rawPassword, Usuario usuario) {
+        String storedPassword = usuario.getPassword();
+        if (storedPassword == null) {
+            return false;
+        }
+
+        if (storedPassword.startsWith("$2")) {
+            return passwordEncoder.matches(rawPassword, storedPassword);
+        }
+
+        if (storedPassword.equals(rawPassword)) {
+            usuario.setPassword(passwordEncoder.encode(rawPassword));
+            usuarioService.guardarUsuario(usuario);
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/transparencia-backend/src/main/java/com/transparencia/api/exception/GlobalExceptionHandler.java
+++ b/transparencia-backend/src/main/java/com/transparencia/api/exception/GlobalExceptionHandler.java
@@ -1,0 +1,46 @@
+package com.transparencia.api.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(RecursoNoEncontradoException.class)
+    public ResponseEntity<Map<String, Object>> manejarNoEncontrado(RecursoNoEncontradoException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+            .body(crearError("NOT_FOUND", ex.getMessage()));
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Map<String, Object>> manejarArgumentoInvalido(IllegalArgumentException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(crearError("BAD_REQUEST", ex.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, Object>> manejarValidacion(MethodArgumentNotValidException ex) {
+        String mensaje = ex.getBindingResult().getFieldErrors().stream()
+            .map(error -> error.getField() + ": " + error.getDefaultMessage())
+            .collect(Collectors.joining(", "));
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(crearError("VALIDATION_ERROR", mensaje));
+    }
+
+    private Map<String, Object> crearError(String error, String mensaje) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("error", error);
+        body.put("mensaje", mensaje);
+        body.put("timestamp", LocalDateTime.now());
+        return body;
+    }
+}

--- a/transparencia-backend/src/main/java/com/transparencia/api/exception/RecursoNoEncontradoException.java
+++ b/transparencia-backend/src/main/java/com/transparencia/api/exception/RecursoNoEncontradoException.java
@@ -1,0 +1,10 @@
+package com.transparencia.api.exception;
+
+public class RecursoNoEncontradoException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public RecursoNoEncontradoException(String mensaje) {
+        super(mensaje);
+    }
+}

--- a/transparencia-backend/src/main/java/com/transparencia/api/model/dto/LoginRequestDTO.java
+++ b/transparencia-backend/src/main/java/com/transparencia/api/model/dto/LoginRequestDTO.java
@@ -1,0 +1,12 @@
+package com.transparencia.api.model.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequestDTO(
+    @NotBlank(message = "El identificador es requerido")
+    String identificador,
+
+    @NotBlank(message = "La contrasena es requerida")
+    String password
+) {
+}

--- a/transparencia-backend/src/main/java/com/transparencia/api/model/dto/RegistroRequestDTO.java
+++ b/transparencia-backend/src/main/java/com/transparencia/api/model/dto/RegistroRequestDTO.java
@@ -1,0 +1,31 @@
+package com.transparencia.api.model.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record RegistroRequestDTO(
+    @NotBlank(message = "El email es requerido")
+    @Email(message = "Formato de email invalido")
+    String email,
+
+    @NotBlank(message = "La contrasena es requerida")
+    @Size(min = 6, max = 100, message = "La contrasena debe tener entre 6 y 100 caracteres")
+    String password,
+
+    @NotBlank(message = "El DNI es requerido")
+    @Pattern(regexp = "\\d{8}", message = "El DNI debe tener exactamente 8 digitos numericos")
+    String dni,
+
+    @NotBlank(message = "El nombre completo es requerido")
+    @Size(max = 200, message = "El nombre no puede exceder 200 caracteres")
+    String nombreCompleto,
+
+    @Size(max = 15, message = "El telefono no puede exceder 15 caracteres")
+    String telefono,
+
+    @Size(max = 300, message = "La direccion no puede exceder 300 caracteres")
+    String direccion
+) {
+}

--- a/transparencia-backend/src/test/java/com/transparencia/api/controller/AuthRestControllerTest.java
+++ b/transparencia-backend/src/test/java/com/transparencia/api/controller/AuthRestControllerTest.java
@@ -1,0 +1,210 @@
+package com.transparencia.api.controller;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import com.transparencia.api.model.entity.Ciudadano;
+import com.transparencia.api.model.entity.Usuario;
+import com.transparencia.api.security.JwtService;
+import com.transparencia.api.service.AdministradorService;
+import com.transparencia.api.service.CiudadanoService;
+import com.transparencia.api.service.FuncionarioService;
+import com.transparencia.api.service.MiembroTTAIPService;
+import com.transparencia.api.service.UsuarioService;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AuthRestController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class AuthRestControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockitoBean
+    UsuarioService usuarioService;
+
+    @MockitoBean
+    CiudadanoService ciudadanoService;
+
+    @MockitoBean
+    FuncionarioService funcionarioService;
+
+    @MockitoBean
+    MiembroTTAIPService miembroTTAIPService;
+
+    @MockitoBean
+    AdministradorService administradorService;
+
+    @MockitoBean
+    JwtService jwtService;
+
+        @MockitoBean
+        UserDetailsService userDetailsService;
+
+    @MockitoBean
+    PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void setUp() {
+        when(passwordEncoder.matches(anyString(), anyString())).thenReturn(false);
+        when(passwordEncoder.encode(anyString())).thenReturn("$2a$12$encodedHash");
+    }
+
+    private Ciudadano crearCiudadano(String password) {
+        Ciudadano ciudadano = new Ciudadano();
+        ciudadano.setIdUsuario(1L);
+        ciudadano.setEmail("ciudadano@test.com");
+        ciudadano.setPassword(password);
+        ciudadano.setTipoUsuario(Usuario.TipoUsuario.CIUDADANO);
+        ciudadano.setActivo(true);
+        ciudadano.setFechaRegistro(LocalDateTime.now());
+        ciudadano.setDni("12345678");
+        ciudadano.setNombreCompleto("Juan Perez");
+        return ciudadano;
+    }
+
+    @Test
+    void loginConDniValido_debeRetornar200YToken() throws Exception {
+        Ciudadano ciudadano = crearCiudadano("$2a$12$hashedpassword");
+        when(ciudadanoService.obtenerCiudadanoPorDni("12345678")).thenReturn(Optional.of(ciudadano));
+        when(ciudadanoService.findById(1L)).thenReturn(Optional.of(ciudadano));
+        when(passwordEncoder.matches("pass123", "$2a$12$hashedpassword")).thenReturn(true);
+        when(jwtService.generateToken(anyString(), anyString(), any())).thenReturn("test.jwt.token");
+
+        mockMvc.perform(post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {"identificador":"12345678","password":"pass123"}
+                    """))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.token").value("test.jwt.token"));
+    }
+
+    @Test
+    void loginConEmail_debeRetornar200YToken() throws Exception {
+        Ciudadano ciudadano = crearCiudadano("$2a$12$hashedpassword");
+        when(usuarioService.obtenerUsuarioPorEmail("ciudadano@test.com")).thenReturn(Optional.of(ciudadano));
+        when(ciudadanoService.findById(1L)).thenReturn(Optional.of(ciudadano));
+        when(passwordEncoder.matches("pass123", "$2a$12$hashedpassword")).thenReturn(true);
+        when(jwtService.generateToken(anyString(), anyString(), any())).thenReturn("test.jwt.token");
+
+        mockMvc.perform(post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {"identificador":"ciudadano@test.com","password":"pass123"}
+                    """))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.token").value("test.jwt.token"));
+    }
+
+    @Test
+    void loginPasswordIncorrecto_debeRetornar401() throws Exception {
+        Ciudadano ciudadano = crearCiudadano("$2a$12$hashedpassword");
+        when(usuarioService.obtenerUsuarioPorEmail("ciudadano@test.com")).thenReturn(Optional.of(ciudadano));
+
+        mockMvc.perform(post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {"identificador":"ciudadano@test.com","password":"wrongpass"}
+                    """))
+            .andExpect(status().isUnauthorized())
+            .andExpect(jsonPath("$.success").value(false));
+    }
+
+    @Test
+    void loginUsuarioInexistente_debeRetornar401() throws Exception {
+        when(usuarioService.obtenerUsuarioPorEmail("noexiste@test.com")).thenReturn(Optional.empty());
+
+        mockMvc.perform(post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {"identificador":"noexiste@test.com","password":"pass123"}
+                    """))
+            .andExpect(status().isUnauthorized())
+            .andExpect(jsonPath("$.success").value(false));
+    }
+
+    @Test
+    void loginUsuarioDesactivado_debeRetornar401() throws Exception {
+        Ciudadano ciudadano = crearCiudadano("$2a$12$hashedpassword");
+        ciudadano.setActivo(false);
+        when(usuarioService.obtenerUsuarioPorEmail("ciudadano@test.com")).thenReturn(Optional.of(ciudadano));
+        when(passwordEncoder.matches("pass123", "$2a$12$hashedpassword")).thenReturn(true);
+
+        mockMvc.perform(post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {"identificador":"ciudadano@test.com","password":"pass123"}
+                    """))
+            .andExpect(status().isUnauthorized())
+            .andExpect(jsonPath("$.success").value(false));
+    }
+
+    @Test
+    void registroExitoso_debeRetornar201() throws Exception {
+        when(usuarioService.obtenerUsuarioPorEmail("nuevo@test.com")).thenReturn(Optional.empty());
+        when(ciudadanoService.obtenerCiudadanoPorDni("87654321")).thenReturn(Optional.empty());
+        Ciudadano ciudadano = crearCiudadano("$2a$12$encoded");
+        ciudadano.setEmail("nuevo@test.com");
+        when(ciudadanoService.guardarCiudadano(any())).thenReturn(ciudadano);
+
+        mockMvc.perform(post("/api/auth/registro")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {"email":"nuevo@test.com","password":"pass123","dni":"87654321","nombreCompleto":"Maria Garcia"}
+                    """))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.success").value(true));
+    }
+
+    @Test
+    void registroEmailDuplicado_debeRetornar400() throws Exception {
+        when(usuarioService.obtenerUsuarioPorEmail("existe@test.com")).thenReturn(Optional.of(crearCiudadano("hash")));
+
+        mockMvc.perform(post("/api/auth/registro")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {"email":"existe@test.com","password":"pass123","dni":"87654321","nombreCompleto":"Maria Garcia"}
+                    """))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.success").value(false));
+    }
+
+    @Test
+    void registroDniInvalido_debeRetornar400() throws Exception {
+        mockMvc.perform(post("/api/auth/registro")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {"email":"nuevo@test.com","password":"pass123","dni":"123","nombreCompleto":"Maria Garcia"}
+                    """))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void registroPasswordCorta_debeRetornar400() throws Exception {
+        mockMvc.perform(post("/api/auth/registro")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {"email":"nuevo@test.com","password":"ab","dni":"87654321","nombreCompleto":"Maria Garcia"}
+                    """))
+            .andExpect(status().isBadRequest());
+    }
+}

--- a/transparencia-backend/src/test/java/com/transparencia/api/security/SecurityConfigAuthorizationTest.java
+++ b/transparencia-backend/src/test/java/com/transparencia/api/security/SecurityConfigAuthorizationTest.java
@@ -25,7 +25,7 @@ class SecurityConfigAuthorizationTest {
         mockMvc.perform(post("/api/auth/login")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{}"))
-            .andExpect(status().isNotFound());
+            .andExpect(status().isBadRequest());
     }
 
     @Test


### PR DESCRIPTION
## Contexto
Se completa HU-01 en el bloque de autenticacion incorporando la cobertura de pruebas unitarias para los endpoints de auth. Este PR incluye el prerequisito BE-04 (endpoints) y el sub-issue BE-05 (tests) presentes en la misma rama HU01.

## Cambios incluidos
* Implementacion de AuthRestController con endpoints login, registro, verificar-email, verificar-dni y me
* DTOs LoginRequestDTO y RegistroRequestDTO con validaciones Jakarta
* GlobalExceptionHandler y RecursoNoEncontradoException para respuestas JSON de error
* AuthRestControllerTest con 9 escenarios BE-05 en @WebMvcTest
* Ajuste menor de SecurityConfigAuthorizationTest por nuevo comportamiento de /api/auth/login

## Trazabilidad de sub-issues
* Closes HU-01 · BE-04 · Crear endpoints de auth #13
* Closes HU-01 · BE-05 · Pruebas unitarias AuthRestControllerTest #14
* Commit 0c459a04b0524e30d9f008f3169d7117cd68a1f3
* Commit a494a0d46ac111ad6bc005fc4048f18f58cc1e9b

## Validacion
* Backend: ./mvnw test -> OK
* Backend build: ./mvnw -DskipTests package -> OK

## Riesgos y mitigaciones
* Riesgo: cambios de autenticacion pueden afectar contratos de login existentes.
* Mitigacion: cobertura de pruebas de login/registro y validacion completa del backend en verde.

## Checklist de revision
- [ ] Validar respuestas de /api/auth/login para DNI y email
- [ ] Validar reglas de registro (email/DNI duplicado y validaciones)
- [ ] Tests y build en verde