### PR TITLE
🔀 feat(HU-04): BE-01 · Entidades Apelacion y Resolucion

### DIFF
--- a/transparencia-backend/src/main/java/com/transparencia/api/model/dto/ApelacionDTO.java
+++ b/transparencia-backend/src/main/java/com/transparencia/api/model/dto/ApelacionDTO.java
@@ -1,0 +1,14 @@
+package com.transparencia.api.model.dto;
+
+import java.time.LocalDateTime;
+import lombok.Data;
+
+@Data
+public class ApelacionDTO {
+    private Long idApelacion;
+    private String expediente;
+    private String estado;
+    private LocalDateTime fechaApelacion;
+    private String ciudadanoNombre;
+    private String solicitudExpediente;
+}

--- a/transparencia-backend/src/main/java/com/transparencia/api/model/dto/ApelacionInfoDTO.java
+++ b/transparencia-backend/src/main/java/com/transparencia/api/model/dto/ApelacionInfoDTO.java
@@ -1,0 +1,16 @@
+package com.transparencia.api.model.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class ApelacionInfoDTO {
+    private Long idApelacion;
+    private String expediente;
+    private String fundamentos;
+    private LocalDateTime fechaApelacion;
+    private String estado;
+    private String resultado;
+    private List<ResolucionDTO> resoluciones;
+}

--- a/transparencia-backend/src/main/java/com/transparencia/api/model/dto/ResolucionDTO.java
+++ b/transparencia-backend/src/main/java/com/transparencia/api/model/dto/ResolucionDTO.java
@@ -1,0 +1,14 @@
+package com.transparencia.api.model.dto;
+
+import java.time.LocalDateTime;
+import lombok.Data;
+
+@Data
+public class ResolucionDTO {
+    private Long idResolucion;
+    private String numeroResolucion;
+    private String tipoResolucion;
+    private String decision;
+    private LocalDateTime fechaResolucion;
+    private String miembroNombre;
+}

--- a/transparencia-backend/src/main/java/com/transparencia/api/model/entity/Apelacion.java
+++ b/transparencia-backend/src/main/java/com/transparencia/api/model/entity/Apelacion.java
@@ -1,20 +1,9 @@
 package com.transparencia.api.model.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -30,44 +19,65 @@ public class Apelacion {
     @Column(name = "id_apelacion")
     private Long idApelacion;
 
-    @Column(length = 50)
+    @Column(length = 50, unique = true)
     private String expediente;
+
+    @OneToOne
+    @JoinColumn(name = "id_solicitud", unique = true)
+    private Solicitud solicitud;
+
+    @ManyToOne
+    @JoinColumn(name = "id_ciudadano")
+    private Ciudadano ciudadano;
+
+    @Column(columnDefinition = "TEXT")
+    private String fundamentos;
+
+    @OneToMany(mappedBy = "apelacion")
+    private List<Documento> documentos;
+
+    @OneToMany(mappedBy = "apelacion")
+    private List<Resolucion> resoluciones;
 
     @Enumerated(EnumType.STRING)
     @Column(length = 40)
     private EstadoApelacion estado;
 
-    @Column(length = 100)
+    @Enumerated(EnumType.STRING)
+    private Calificacion calificacionPrimera;
+
+    @Enumerated(EnumType.STRING)
+    private Calificacion calificacionSegunda;
+
     private String resultado;
-
-    @Column(name = "fecha_apelacion")
     private LocalDateTime fechaApelacion;
-
-    @Column(name = "fecha_subsanacion")
     private LocalDateTime fechaSubsanacion;
-
-    @Column(name = "dias_subsanacion")
     private Integer diasSubsanacion;
 
-    @OneToOne
-    @JoinColumn(name = "id_solicitud")
-    private Solicitud solicitud;
-
-    @OneToMany(mappedBy = "apelacion")
-    private List<Documento> documentos;
-
     public enum EstadoApelacion {
-        PENDIENTE_ELEVACION,
-        EN_CALIFICACION_1,
-        EN_SUBSANACION,
-        EN_CALIFICACION_2,
-        EN_RESOLUCION,
-        RESUELTO
+        PENDIENTE_ELEVACION, EN_CALIFICACION_1, EN_SUBSANACION, EN_CALIFICACION_2, 
+        NOTIFICACION_SEGUNDA_CALIFICACION, EN_RESOLUCION, RESUELTO, TENER_POR_NO_PRESENTADO, 
+        CONCLUSION_SUSTRACCION_MATERIA, CONCLUSION_DESISTIMIENTO, RESUELTO_FUNDADO, 
+        RESUELTO_FUNDADO_EN_PARTE, RESUELTO_INFUNDADO, RESUELTO_INFUNDADO_EN_PARTE, 
+        RESUELTO_IMPROCEDENTE
+    }
+
+    public enum Calificacion {
+        ADMISIBLE, INADMISIBLE, IMPROCEDENTE, ADMITIDO
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        this.fechaApelacion = LocalDateTime.now();
+        if (this.estado == null) this.estado = EstadoApelacion.PENDIENTE_ELEVACION;
+    }
+
+    public boolean isResuelta() {
+        return this.estado != null && (this.estado == EstadoApelacion.RESUELTO || 
+               this.estado.name().startsWith("RESUELTO_"));
     }
 
     public Long getId() {
         return this.idApelacion;
     }
 }
-
-//apleacion

--- a/transparencia-backend/src/main/java/com/transparencia/api/model/entity/Apelacion.java
+++ b/transparencia-backend/src/main/java/com/transparencia/api/model/entity/Apelacion.java
@@ -69,3 +69,5 @@ public class Apelacion {
         return this.idApelacion;
     }
 }
+
+//apleacion

--- a/transparencia-backend/src/main/java/com/transparencia/api/model/entity/Resolucion.java
+++ b/transparencia-backend/src/main/java/com/transparencia/api/model/entity/Resolucion.java
@@ -1,14 +1,11 @@
 package com.transparencia.api.model.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Data
 @NoArgsConstructor
@@ -21,6 +18,55 @@ public class Resolucion {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id_resolucion")
     private Long idResolucion;
+
+    @ManyToOne
+    @JoinColumn(name = "id_apelacion")
+    private Apelacion apelacion;
+
+    @ManyToOne
+    @JoinColumn(name = "id_miembro_ttaip")
+    private MiembroTTAIP miembroTTAIP;
+
+    @Column(unique = true, length = 50)
+    private String numeroResolucion;
+
+    @Column(columnDefinition = "TEXT")
+    private String fundamentos;
+
+    @Column(columnDefinition = "TEXT")
+    private String fundamentoLegal;
+
+    private LocalDateTime fechaResolucion;
+    
+    @Column(columnDefinition = "TEXT")
+    private String observaciones;
+
+    @Column(length = 500)
+    private String causalFundado;
+
+    @Column(length = 20)
+    private String resultado;
+
+    private Boolean iniciarProcesoDisciplinario;
+
+    @OneToMany(mappedBy = "resolucion")
+    private List<Documento> documentos;
+
+    @Enumerated(EnumType.STRING)
+    private TipoResolucion tipoResolucion;
+
+    @Enumerated(EnumType.STRING)
+    private DecisionResolucion decision;
+
+    public enum TipoResolucion {
+        PRIMERA_CALIFICACION, SEGUNDA_CALIFICACION, RESOLUCION_FINAL
+    }
+
+    public enum DecisionResolucion {
+        ADMISIBLE, INADMISIBLE, IMPROCEDENTE, ADMITIDO, TENER_POR_NO_PRESENTADO, 
+        FUNDADO, FUNDADO_EN_PARTE, INFUNDADO, INFUNDADO_EN_PARTE, 
+        CONCLUSION_SUSTRACCION_MATERIA, CONCLUSION_DESISTIMIENTO
+    }
 
     public Long getId() {
         return this.idResolucion;


### PR DESCRIPTION
## Contexto
El sub-issue BE-01 de la HU-04 requiere la creación de las entidades base para el proceso de apelaciones, incluyendo sus relaciones, campos legales y los DTOs para la transferencia de datos.

## Cambios incluidos
* Se crea la entidad `Apelacion` con sus 15 estados y campos requeridos.
* Se crea la entidad `Resolucion` con sus mapeos JPA y flag disciplinario.
* Se implementan `ApelacionDTO`, `ApelacionInfoDTO` y `ResolucionDTO`.
* Se configuran las relaciones `@OneToOne`, `@OneToMany` y `@ManyToOne` entre las entidades.

## Trazabilidad de sub-issues
* Closes #36

## Checklist de revisión
- [x] Las entidades incluyen todos los campos del backlog.
- [x] Los Enums contienen todos los valores requeridos.
- [x] Los DTOs están creados en la carpeta correcta.