### PR TITLE
✨ feat(HU-04): FE-03 · Implementar modelo y servicio de apelaciones

### DIFF
--- a/transparencia-frontend/src/app/models/apelacion.model.ts
+++ b/transparencia-frontend/src/app/models/apelacion.model.ts
@@ -1,0 +1,45 @@
+export enum EstadoApelacion {
+  PENDIENTE_ELEVACION = 'PENDIENTE_ELEVACION',
+  EN_CALIFICACION_1 = 'EN_CALIFICACION_1',
+  EN_SUBSANACION = 'EN_SUBSANACION',
+  EN_CALIFICACION_2 = 'EN_CALIFICACION_2',
+  NOTIFICACION_SEGUNDA_CALIFICACION = 'NOTIFICACION_SEGUNDA_CALIFICACION',
+  EN_RESOLUCION = 'EN_RESOLUCION',
+  RESUELTO = 'RESUELTO',
+  TENER_POR_NO_PRESENTADO = 'TENER_POR_NO_PRESENTADO',
+  CONCLUSION_SUSTRACCION_MATERIA = 'CONCLUSION_SUSTRACCION_MATERIA',
+  CONCLUSION_DESISTIMIENTO = 'CONCLUSION_DESISTIMIENTO',
+  RESUELTO_FUNDADO = 'RESUELTO_FUNDADO',
+  RESUELTO_FUNDADO_EN_PARTE = 'RESUELTO_FUNDADO_EN_PARTE',
+  RESUELTO_INFUNDADO = 'RESUELTO_INFUNDADO',
+  RESUELTO_INFUNDADO_EN_PARTE = 'RESUELTO_INFUNDADO_EN_PARTE',
+  RESUELTO_IMPROCEDENTE = 'RESUELTO_IMPROCEDENTE'
+}
+
+export enum CalificacionApelacion {
+  ADMISIBLE = 'ADMISIBLE',
+  INADMISIBLE = 'INADMISIBLE',
+  IMPROCEDENTE = 'IMPROCEDENTE',
+  ADMITIDO = 'ADMITIDO'
+}
+
+export interface Apelacion {
+  idApelacion: number;
+  expediente: string;
+  solicitudId: number;
+  ciudadanoId: number;
+  fundamentos: string;
+  fechaApelacion: string;
+  estado: EstadoApelacion;
+  calificacionPrimera?: CalificacionApelacion;
+  calificacionSegunda?: CalificacionApelacion;
+  fechaSubsanacion?: string;
+  diasSubsanacion?: number;
+  resultado?: string;
+}
+
+export interface ApelacionCreate {
+  solicitudId: number;
+  ciudadanoId: number;
+  fundamentos: string;
+}

--- a/transparencia-frontend/src/app/services/apelacion.service.ts
+++ b/transparencia-frontend/src/app/services/apelacion.service.ts
@@ -1,0 +1,58 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { Apelacion, ApelacionCreate, EstadoApelacion } from '../models/apelacion.model';
+
+@Injectable({
+    providedIn: 'root'
+})
+export class ApelacionService {
+
+    private apiUrl = 'http://localhost:8080/api/apelaciones';
+
+    constructor(private http: HttpClient) { }
+
+    findAll(): Observable<Apelacion[]> {
+        return this.http.get<Apelacion[]>(this.apiUrl);
+    }
+
+    findById(id: number): Observable<Apelacion> {
+        return this.http.get<Apelacion>(`${this.apiUrl}/${id}`);
+    }
+
+    findByExpediente(expediente: string): Observable<Apelacion> {
+        return this.http.get<Apelacion>(`${this.apiUrl}/expediente/${expediente}`);
+    }
+
+    findByEstado(estado: EstadoApelacion): Observable<Apelacion[]> {
+        return this.http.get<Apelacion[]>(`${this.apiUrl}/estado/${estado}`);
+    }
+
+    findByCiudadanoId(ciudadanoId: number): Observable<Apelacion[]> {
+        return this.http.get<Apelacion[]>(`${this.apiUrl}/ciudadano/${ciudadanoId}`);
+    }
+
+    getEstadisticas(): Observable<any> {
+        return this.http.get<any>(`${this.apiUrl}/estadisticas`);
+    }
+
+    crear(data: ApelacionCreate): Observable<Apelacion> {
+        return this.http.post<Apelacion>(this.apiUrl, data);
+    }
+
+    actualizar(id: number, data: Partial<Apelacion>): Observable<Apelacion> {
+        return this.http.put<Apelacion>(`${this.apiUrl}/${id}`, data);
+    }
+
+    cambiarEstado(id: number, estado: EstadoApelacion): Observable<Apelacion> {
+        return this.http.patch<Apelacion>(`${this.apiUrl}/${id}/estado`, { estado });
+    }
+
+    subsanar(id: number, fundamentosAdicionales: string): Observable<Apelacion> {
+        return this.http.post<Apelacion>(`${this.apiUrl}/${id}/subsanacion`, { fundamentosAdicionales });
+    }
+
+    eliminar(id: number): Observable<void> {
+        return this.http.delete<void>(`${this.apiUrl}/${id}`);
+    }
+}


### PR DESCRIPTION
## Contexto
Se implementa la capa de comunicación del Frontend (modelos y servicios) para la HU-04, dejando todo listo para la conexión de los componentes visuales.

## Cambios incluidos
- `apelacion.model.ts`: Creación de interfaces y enum de 15 estados.
- `apelacion.service.ts`: Implementación de métodos CRUD y llamadas HTTP.

## Checklist de revisión
- [x] Modelos tipados correctamente.
- [x] Endpoints apuntan a la URL correcta.