### PR TITLE
🔀 feat(HU-02): FE-02 · crear upload reutilizable

### DIFF
--- a/transparencia-frontend/src/app/app.routes.ts
+++ b/transparencia-frontend/src/app/app.routes.ts
@@ -5,6 +5,14 @@ export const routes: Routes = [
     loadComponent: () => import('./pages/ciudadano/nueva-saip.component').then(m => m.NuevaSaipComponent)
   },
   {
+    path: 'ciudadano/nueva-apelacion',
+    loadComponent: () => import('./pages/ciudadano/nueva-apelacion.component').then(m => m.NuevaApelacionComponent)
+  },
+  {
+    path: 'ciudadano/subsanacion',
+    loadComponent: () => import('./pages/ciudadano/subsanacion.component').then(m => m.SubsanacionComponent)
+  },
+  {
     path: 'ttaip',
     loadComponent: () => import('./pages/ttaip/ttaip-dashboard.component').then(m => m.TtaipDashboardComponent)
   },

--- a/transparencia-frontend/src/app/components/file-upload/file-upload.component.css
+++ b/transparencia-frontend/src/app/components/file-upload/file-upload.component.css
@@ -1,0 +1,133 @@
+:host {
+  display: block;
+}
+
+.upload-slot {
+  border: 2px dashed var(--ceniza-claro, #e5e5e5);
+  border-radius: 0.9rem;
+  background: #ffffff;
+  padding: 0.9rem;
+  min-height: 184px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  transition: border-color 180ms ease, background-color 180ms ease, transform 180ms ease;
+}
+
+.upload-slot:hover {
+  border-color: rgba(200, 16, 46, 0.35);
+}
+
+.upload-slot-dragging {
+  border-color: var(--peru-rojo, #c8102e);
+  background: var(--peru-rojo-suave, #fef2f2);
+  transform: translateY(-2px);
+}
+
+.upload-slot-complete {
+  border-color: var(--estado-verde, #059669);
+  background: var(--estado-verde-suave, #ecfdf5);
+}
+
+.upload-slot-header {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.upload-slot-index {
+  width: 1.6rem;
+  height: 1.6rem;
+  border-radius: 999px;
+  display: inline-grid;
+  place-items: center;
+  font-weight: 700;
+  color: #ffffff;
+  background: var(--peru-rojo, #c8102e);
+  font-size: 0.75rem;
+}
+
+.upload-slot-title {
+  font-weight: 600;
+  color: var(--carbon, #171717);
+  font-size: 0.9rem;
+}
+
+.upload-slot-hint {
+  color: var(--niebla, #737373);
+  font-size: 0.7rem;
+}
+
+.upload-select {
+  border: 1px solid var(--ceniza-claro, #e5e5e5);
+  border-radius: 0.75rem;
+  padding: 0.8rem;
+  min-height: 82px;
+  display: grid;
+  place-items: center;
+  text-align: center;
+  font-size: 0.82rem;
+  color: var(--niebla, #737373);
+  cursor: pointer;
+  background: #ffffff;
+}
+
+.upload-select:hover {
+  border-color: rgba(200, 16, 46, 0.35);
+}
+
+.upload-preview {
+  border: 1px solid var(--ceniza-claro, #e5e5e5);
+  border-radius: 0.75rem;
+  background: #ffffff;
+  padding: 0.6rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.upload-preview-name {
+  color: var(--carbon, #171717);
+  font-size: 0.84rem;
+  font-weight: 600;
+  line-height: 1.25rem;
+  word-break: break-word;
+}
+
+.upload-preview-meta {
+  color: var(--niebla, #737373);
+  font-size: 0.72rem;
+}
+
+.upload-remove {
+  align-self: flex-start;
+  border: none;
+  border-radius: 0.5rem;
+  background: var(--peru-rojo-suave, #fef2f2);
+  color: var(--peru-rojo, #c8102e);
+  cursor: pointer;
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.35rem 0.6rem;
+}
+
+.upload-remove:hover {
+  background: #fde6e8;
+}
+
+.upload-error {
+  margin-top: auto;
+  color: var(--estado-rojo, #dc2626);
+  font-size: 0.75rem;
+}
+
+.upload-summary {
+  border-radius: 0.75rem;
+  border: 1px solid var(--ceniza-claro, #e5e5e5);
+  background: var(--nieve, #f5f5f5);
+  padding: 0.75rem;
+  color: var(--niebla, #737373);
+  font-size: 0.74rem;
+  display: grid;
+  gap: 0.2rem;
+}

--- a/transparencia-frontend/src/app/components/file-upload/file-upload.component.html
+++ b/transparencia-frontend/src/app/components/file-upload/file-upload.component.html
@@ -1,0 +1,50 @@
+<div class="file-upload space-y-4">
+  <div class="grid grid-cols-1 md:grid-cols-3 gap-3">
+    @for (slot of slotViewModels(); track slot.index) {
+      <article
+        class="upload-slot"
+        [class.upload-slot-dragging]="slot.isDragging"
+        [class.upload-slot-complete]="slot.file !== null"
+        (dragover)="onDragOver($event, slot.index)"
+        (dragleave)="onDragLeave($event, slot.index)"
+        (drop)="onDrop($event, slot.index)"
+      >
+        <header class="upload-slot-header">
+          <span class="upload-slot-index">{{ slot.index }}</span>
+          <div>
+            <p class="upload-slot-title">Archivo {{ slot.index }}</p>
+            <p class="upload-slot-hint">Max 10MB · PDF/JPG/PNG/DOC/DOCX</p>
+          </div>
+        </header>
+
+        @if (slot.file) {
+          <div class="upload-preview">
+            <p class="upload-preview-name">{{ slot.file.name }}</p>
+            <p class="upload-preview-meta">{{ formatFileSize(slot.file.size) }} · {{ slot.file.type || 'extension validada' }}</p>
+            <button type="button" class="upload-remove" (click)="removeFile(slot.index)">Quitar</button>
+          </div>
+        } @else {
+          <label class="upload-select" [attr.for]="'upload-input-' + slot.index">
+            <span>Arrastra aqui o haz clic para seleccionar</span>
+          </label>
+          <input
+            class="sr-only"
+            type="file"
+            [id]="'upload-input-' + slot.index"
+            [accept]="acceptTypes"
+            (change)="onSelectFile($event, slot.index)"
+          />
+        }
+
+        @if (slot.error) {
+          <p class="upload-error">{{ slot.error }}</p>
+        }
+      </article>
+    }
+  </div>
+
+  <div class="upload-summary">
+    <p>Archivos cargados: {{ uploadedFiles().length }} / {{ maxFilesSafe() }}</p>
+    <p>Tipos permitidos: PDF, JPG, PNG, DOC, DOCX · Maximo 10MB por archivo.</p>
+  </div>
+</div>

--- a/transparencia-frontend/src/app/components/file-upload/file-upload.component.ts
+++ b/transparencia-frontend/src/app/components/file-upload/file-upload.component.ts
@@ -1,0 +1,222 @@
+import { ChangeDetectionStrategy, Component, computed, input, output, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+type SlotIndex = 1 | 2 | 3;
+type SlotRecord<T> = Record<SlotIndex, T>;
+
+interface UploadSlotViewModel {
+  index: SlotIndex;
+  file: File | null;
+  isDragging: boolean;
+  error: string | null;
+}
+
+const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
+const ALLOWED_EXTENSIONS = new Set(['pdf', 'jpg', 'jpeg', 'png', 'doc', 'docx']);
+const ALLOWED_MIME_TYPES = new Set([
+  'application/pdf',
+  'image/jpeg',
+  'image/png',
+  'application/msword',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+]);
+
+@Component({
+  selector: 'app-file-upload',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [CommonModule],
+  templateUrl: './file-upload.component.html',
+  styleUrl: './file-upload.component.css',
+})
+export class FileUploadComponent {
+  readonly maxFiles = input<number>(3);
+  readonly filesChanged = output<File[]>();
+
+  readonly file1 = signal<File | null>(null);
+  readonly file2 = signal<File | null>(null);
+  readonly file3 = signal<File | null>(null);
+
+  readonly acceptTypes = '.pdf,.jpg,.jpeg,.png,.doc,.docx';
+
+  private readonly draggingBySlot = signal<SlotRecord<boolean>>({
+    1: false,
+    2: false,
+    3: false,
+  });
+
+  private readonly errorsBySlot = signal<SlotRecord<string | null>>({
+    1: null,
+    2: null,
+    3: null,
+  });
+
+  readonly maxFilesSafe = computed(() => {
+    const value = Number(this.maxFiles());
+    if (!Number.isFinite(value)) {
+      return 3;
+    }
+    return Math.max(1, Math.min(3, Math.floor(value)));
+  });
+
+  readonly visibleSlots = computed<SlotIndex[]>(() => {
+    return [1, 2, 3].slice(0, this.maxFilesSafe()) as SlotIndex[];
+  });
+
+  readonly slotViewModels = computed<UploadSlotViewModel[]>(() => {
+    const dragging = this.draggingBySlot();
+    const errors = this.errorsBySlot();
+
+    return this.visibleSlots().map((index) => ({
+      index,
+      file: this.getFile(index),
+      isDragging: dragging[index],
+      error: errors[index],
+    }));
+  });
+
+  readonly uploadedFiles = computed<File[]>(() => {
+    return this.visibleSlots()
+      .map((slot) => this.getFile(slot))
+      .filter((file): file is File => file !== null);
+  });
+
+  onDragOver(event: DragEvent, slot: SlotIndex): void {
+    event.preventDefault();
+    if (!this.isSlotVisible(slot)) {
+      return;
+    }
+    this.setDragging(slot, true);
+  }
+
+  onDragLeave(event: DragEvent, slot: SlotIndex): void {
+    event.preventDefault();
+    this.setDragging(slot, false);
+  }
+
+  onDrop(event: DragEvent, slot: SlotIndex): void {
+    event.preventDefault();
+    this.setDragging(slot, false);
+
+    if (!this.isSlotVisible(slot)) {
+      return;
+    }
+
+    const droppedFile = event.dataTransfer?.files?.[0];
+    if (!droppedFile) {
+      return;
+    }
+
+    this.tryAssignFile(slot, droppedFile);
+  }
+
+  onSelectFile(event: Event, slot: SlotIndex): void {
+    if (!this.isSlotVisible(slot)) {
+      return;
+    }
+
+    const input = event.target as HTMLInputElement;
+    const selectedFile = input.files?.[0];
+
+    if (selectedFile) {
+      this.tryAssignFile(slot, selectedFile);
+    }
+
+    input.value = '';
+  }
+
+  removeFile(slot: SlotIndex): void {
+    this.setFile(slot, null);
+    this.setError(slot, null);
+    this.emitFiles();
+  }
+
+  formatFileSize(bytes: number): string {
+    if (bytes >= 1024 * 1024) {
+      return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+    }
+
+    if (bytes >= 1024) {
+      return `${(bytes / 1024).toFixed(1)} KB`;
+    }
+
+    return `${bytes} B`;
+  }
+
+  private tryAssignFile(slot: SlotIndex, file: File): void {
+    const validationError = this.validateFile(file);
+
+    if (validationError) {
+      this.setError(slot, validationError);
+      return;
+    }
+
+    this.setError(slot, null);
+    this.setFile(slot, file);
+    this.emitFiles();
+  }
+
+  private validateFile(file: File): string | null {
+    if (file.size > MAX_FILE_SIZE_BYTES) {
+      return 'El archivo supera el limite de 10MB.';
+    }
+
+    const extension = file.name.split('.').pop()?.toLowerCase() ?? '';
+    if (!ALLOWED_EXTENSIONS.has(extension)) {
+      return 'Tipo de archivo no permitido. Use PDF, JPG, PNG, DOC o DOCX.';
+    }
+
+    if (file.type && !ALLOWED_MIME_TYPES.has(file.type)) {
+      return 'El tipo MIME del archivo no es valido para la carga.';
+    }
+
+    return null;
+  }
+
+  private isSlotVisible(slot: SlotIndex): boolean {
+    return this.visibleSlots().includes(slot);
+  }
+
+  private setDragging(slot: SlotIndex, value: boolean): void {
+    this.draggingBySlot.update((current) => ({
+      ...current,
+      [slot]: value,
+    }));
+  }
+
+  private setError(slot: SlotIndex, value: string | null): void {
+    this.errorsBySlot.update((current) => ({
+      ...current,
+      [slot]: value,
+    }));
+  }
+
+  private setFile(slot: SlotIndex, value: File | null): void {
+    if (slot === 1) {
+      this.file1.set(value);
+      return;
+    }
+
+    if (slot === 2) {
+      this.file2.set(value);
+      return;
+    }
+
+    this.file3.set(value);
+  }
+
+  private getFile(slot: SlotIndex): File | null {
+    if (slot === 1) {
+      return this.file1();
+    }
+
+    if (slot === 2) {
+      return this.file2();
+    }
+
+    return this.file3();
+  }
+
+  private emitFiles(): void {
+    this.filesChanged.emit(this.uploadedFiles());
+  }
+}

--- a/transparencia-frontend/src/app/pages/ciudadano/nueva-apelacion.component.css
+++ b/transparencia-frontend/src/app/pages/ciudadano/nueva-apelacion.component.css
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/transparencia-frontend/src/app/pages/ciudadano/nueva-apelacion.component.html
+++ b/transparencia-frontend/src/app/pages/ciudadano/nueva-apelacion.component.html
@@ -1,0 +1,28 @@
+<main class="min-h-screen bg-[var(--nieve)] text-[var(--carbon)] p-4 md:p-6">
+  <section class="max-w-5xl mx-auto space-y-5">
+    <header class="card-elevated p-5 md:p-6">
+      <a routerLink="/" class="text-sm text-[var(--niebla)] hover:text-[var(--carbon)]">Volver</a>
+      <h1 class="mt-3 text-2xl font-bold tracking-tight">Nueva Apelacion</h1>
+      <p class="text-sm text-[var(--niebla)] mt-1">
+        Adjunte los 3 documentos requeridos para presentar su apelacion ante TTAIP.
+      </p>
+    </header>
+
+    <section class="card-elevated p-5 md:p-6 space-y-4">
+      <div class="section-header">
+        <div class="section-index">1</div>
+        <h2 class="section-title">Documentos requeridos</h2>
+      </div>
+
+      <app-file-upload [maxFiles]="3" (filesChanged)="onFilesChanged($event)"></app-file-upload>
+
+      <div class="rounded-xl border border-[var(--ceniza-claro)] bg-[var(--nieve)] p-3 text-sm text-[var(--niebla)]">
+        Estado de carga: {{ documentos().length }} de 3 archivos.
+      </div>
+
+      <button type="button" class="btn-primary h-11 w-full" [disabled]="documentos().length < 3">
+        Continuar con fundamentos
+      </button>
+    </section>
+  </section>
+</main>

--- a/transparencia-frontend/src/app/pages/ciudadano/nueva-apelacion.component.ts
+++ b/transparencia-frontend/src/app/pages/ciudadano/nueva-apelacion.component.ts
@@ -1,0 +1,19 @@
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterLink } from '@angular/router';
+import { FileUploadComponent } from '../../components/file-upload/file-upload.component';
+
+@Component({
+  selector: 'app-nueva-apelacion',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [CommonModule, RouterLink, FileUploadComponent],
+  templateUrl: './nueva-apelacion.component.html',
+  styleUrl: './nueva-apelacion.component.css',
+})
+export class NuevaApelacionComponent {
+  readonly documentos = signal<File[]>([]);
+
+  onFilesChanged(files: File[]): void {
+    this.documentos.set(files);
+  }
+}

--- a/transparencia-frontend/src/app/pages/ciudadano/nueva-saip.component.html
+++ b/transparencia-frontend/src/app/pages/ciudadano/nueva-saip.component.html
@@ -147,11 +147,10 @@
                 </h3>
               </div>
 
-              <div class="upload-zone">
-                <p class="text-sm text-[var(--niebla)]">
-                  Arrastra archivos o <span class="font-medium text-[var(--peru-rojo)]">haz clic para seleccionar</span>
-                </p>
-                <p class="text-xs text-[var(--niebla)] mt-1">PDF, DOC, DOCX, JPG, PNG (max. 5MB)</p>
+              <app-file-upload [maxFiles]="3" (filesChanged)="onFilesChanged($event)"></app-file-upload>
+
+              <div class="rounded-xl border border-[var(--ceniza-claro)] bg-[var(--nieve)] px-3 py-2 text-xs text-[var(--niebla)]">
+                Archivos cargados: {{ adjuntos().length }} de 3.
               </div>
             </div>
 

--- a/transparencia-frontend/src/app/pages/ciudadano/nueva-saip.component.ts
+++ b/transparencia-frontend/src/app/pages/ciudadano/nueva-saip.component.ts
@@ -19,6 +19,7 @@ import { EntidadService } from '../../services/entidad.service';
 import { SolicitudService } from '../../services/solicitud.service';
 import { Entidad } from '../../models/entidad.model';
 import { SolicitudCreate } from '../../models/solicitud.model';
+import { FileUploadComponent } from '../../components/file-upload/file-upload.component';
 
 interface SesionUsuario {
   ciudadanoId?: number;
@@ -45,7 +46,7 @@ const alMenosUnFormatoSeleccionado: ValidatorFn = (group) => {
 @Component({
   selector: 'app-nueva-saip',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, ReactiveFormsModule, RouterLink],
+  imports: [CommonModule, ReactiveFormsModule, RouterLink, FileUploadComponent],
   templateUrl: './nueva-saip.component.html',
   styleUrl: './nueva-saip.component.css',
 })
@@ -60,6 +61,7 @@ export class NuevaSaipComponent {
   readonly submitting = signal(false);
   readonly error = signal<string | null>(null);
   readonly success = signal<string | null>(null);
+  readonly adjuntos = signal<File[]>([]);
 
   readonly form = this.fb.group(
     {
@@ -148,6 +150,10 @@ export class NuevaSaipComponent {
         this.error.set(mensaje ?? 'No se pudo registrar la solicitud SAIP.');
       },
     });
+  }
+
+  onFilesChanged(files: File[]): void {
+    this.adjuntos.set(files);
   }
 
   private obtenerCiudadanoIdDesdeSesion(): number | null {

--- a/transparencia-frontend/src/app/pages/ciudadano/subsanacion.component.css
+++ b/transparencia-frontend/src/app/pages/ciudadano/subsanacion.component.css
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/transparencia-frontend/src/app/pages/ciudadano/subsanacion.component.html
+++ b/transparencia-frontend/src/app/pages/ciudadano/subsanacion.component.html
@@ -1,0 +1,28 @@
+<main class="min-h-screen bg-[var(--nieve)] text-[var(--carbon)] p-4 md:p-6">
+  <section class="max-w-5xl mx-auto space-y-5">
+    <header class="card-elevated p-5 md:p-6">
+      <a routerLink="/" class="text-sm text-[var(--niebla)] hover:text-[var(--carbon)]">Volver</a>
+      <h1 class="mt-3 text-2xl font-bold tracking-tight">Subsanacion de Apelacion</h1>
+      <p class="text-sm text-[var(--niebla)] mt-1">
+        Adjunte documentos de subsanacion para levantar observaciones de primera calificacion.
+      </p>
+    </header>
+
+    <section class="card-elevated p-5 md:p-6 space-y-4">
+      <div class="section-header">
+        <div class="section-index">1</div>
+        <h2 class="section-title">Documentos de subsanacion</h2>
+      </div>
+
+      <app-file-upload [maxFiles]="3" (filesChanged)="onFilesChanged($event)"></app-file-upload>
+
+      <div class="rounded-xl border border-[var(--ceniza-claro)] bg-[var(--nieve)] p-3 text-sm text-[var(--niebla)]">
+        Archivos cargados: {{ adjuntos().length }} de 3.
+      </div>
+
+      <button type="button" class="btn-primary h-11 w-full" [disabled]="adjuntos().length === 0">
+        Enviar subsanacion
+      </button>
+    </section>
+  </section>
+</main>

--- a/transparencia-frontend/src/app/pages/ciudadano/subsanacion.component.ts
+++ b/transparencia-frontend/src/app/pages/ciudadano/subsanacion.component.ts
@@ -1,0 +1,19 @@
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterLink } from '@angular/router';
+import { FileUploadComponent } from '../../components/file-upload/file-upload.component';
+
+@Component({
+  selector: 'app-subsanacion',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [CommonModule, RouterLink, FileUploadComponent],
+  templateUrl: './subsanacion.component.html',
+  styleUrl: './subsanacion.component.css',
+})
+export class SubsanacionComponent {
+  readonly adjuntos = signal<File[]>([]);
+
+  onFilesChanged(files: File[]): void {
+    this.adjuntos.set(files);
+  }
+}


### PR DESCRIPTION
## Contexto
Se implementa FE-02 de HU-02 para estandarizar la carga de documentos y reutilizar una sola lógica de adjuntos en los flujos ciudadanos.

## Cambios incluidos
- Se crea un componente reusable de carga de archivos con drag and drop y tres slots.
- Se agregan validaciones de tamaño/tipo de archivo, preview y eliminación por archivo.
- Se integra el componente en Nueva SAIP.
- Se incorpora el mismo componente en Nueva Apelación y Subsanación.
- Se agregan rutas lazy para las vistas ciudadanas nuevas asociadas al flujo FE-02.

## Trazabilidad de sub-issues
- [x] Closes #25 · FE-02 Componente de subida de archivos.
- Commit asociado: 90bab15.

## Validación
- Frontend tests: `npm test -- --watch=false` (6/6)
- Frontend build: `npm run build` (OK)

## Riesgos y mitigaciones
- Riesgo: las vistas base de Nueva Apelación/Subsanación pueden requerir ampliaciones en sub-issues posteriores.
- Mitigación: el alcance del PR se mantiene en FE-02 (componente reusable + integración), sin cambios de backend.

## Checklist de revisión
- [x] Alcance FE-02 completado
- [x] Reutilización en 3 pantallas
- [x] Tests/build frontend en verde
- [x] Sin secretos en el diff