### PR TITLE
🔀 feat(HU-02): FE-03 · integrar creación SAIP con confirmación y redirección

### DIFF
--- a/transparencia-frontend/src/app/app.routes.ts
+++ b/transparencia-frontend/src/app/app.routes.ts
@@ -1,6 +1,11 @@
 import { Routes } from '@angular/router';
 export const routes: Routes = [
   {
+    path: 'ciudadano',
+    redirectTo: 'ciudadano/nueva-saip',
+    pathMatch: 'full'
+  },
+  {
     path: 'ciudadano/nueva-saip',
     loadComponent: () => import('./pages/ciudadano/nueva-saip.component').then(m => m.NuevaSaipComponent)
   },

--- a/transparencia-frontend/src/app/pages/ciudadano/nueva-saip.component.css
+++ b/transparencia-frontend/src/app/pages/ciudadano/nueva-saip.component.css
@@ -115,14 +115,6 @@
   font-size: 0.875rem;
 }
 
-.alert-success {
-  border: 1px solid var(--estado-verde-borde);
-  border-radius: 0.8rem;
-  background: var(--estado-verde-suave);
-  color: var(--estado-verde);
-  padding: 0.75rem;
-  font-size: 0.875rem;
-}
 
 .option-card {
   display: flex;
@@ -146,19 +138,6 @@
   accent-color: var(--peru-rojo);
 }
 
-.upload-zone {
-  border: 2px dashed var(--ceniza-claro);
-  border-radius: 0.9rem;
-  padding: 1.5rem;
-  text-align: center;
-  background: #ffffff;
-  transition: border-color 180ms ease, background-color 180ms ease;
-}
-
-.upload-zone:hover {
-  border-color: rgba(200, 16, 46, 0.35);
-  background: #fffdfd;
-}
 
 .btn-primary,
 .btn-outline {

--- a/transparencia-frontend/src/app/pages/ciudadano/nueva-saip.component.html
+++ b/transparencia-frontend/src/app/pages/ciudadano/nueva-saip.component.html
@@ -20,10 +20,6 @@
               <div class="alert-error animate-fade-in">{{ error() }}</div>
             }
 
-            @if (success()) {
-              <div class="alert-success animate-fade-in">{{ success() }}</div>
-            }
-
             <div class="space-y-4">
               <div class="section-header">
                 <div class="section-index">1</div>
@@ -157,13 +153,23 @@
             <div class="flex flex-col sm:flex-row gap-3 pt-4 border-t border-[var(--ceniza-claro)]">
               <button type="submit" [disabled]="submitting()" class="btn-primary flex-1 h-12">
                 @if (submitting()) {
-                  Registrando...
+                  <span class="inline-flex items-center gap-2">
+                    <span class="inline-block h-3.5 w-3.5 rounded-full border-2 border-white/35 border-t-white animate-spin" aria-hidden="true"></span>
+                    Registrando...
+                  </span>
                 } @else {
                   Presentar SAIP
                 }
               </button>
               <a routerLink="/" class="btn-outline flex-1 h-12">Cancelar</a>
             </div>
+
+            @if (submitting()) {
+              <div class="flex items-center gap-2 rounded-xl border border-[var(--ceniza-claro)] bg-[var(--nieve)] px-3 py-2 text-sm text-[var(--niebla)] animate-fade-in">
+                <span class="inline-block h-3.5 w-3.5 rounded-full border-2 border-[rgba(23,23,23,0.18)] border-t-[var(--peru-rojo)] animate-spin" aria-hidden="true"></span>
+                Enviando solicitud a la entidad seleccionada...
+              </div>
+            }
           </form>
         </div>
       </div>
@@ -208,4 +214,19 @@
       </aside>
     </div>
   </section>
+
+  @if (confirmacionVisible()) {
+    <div class="fixed inset-0 z-60 grid place-items-center bg-[rgba(23,23,23,0.55)] p-4">
+      <section class="w-full max-w-md rounded-2xl border border-[var(--ceniza-claro)] bg-white p-5 text-center shadow-[0_10px_26px_-8px_rgba(23,23,23,0.12),0_3px_10px_rgba(23,23,23,0.06)] animate-fade-in" role="dialog" aria-modal="true" aria-labelledby="confirmacion-saip-titulo">
+        <div class="mx-auto mb-3 grid h-9 w-9 place-items-center rounded-full border border-[var(--estado-verde-borde)] bg-[var(--estado-verde-suave)] text-[var(--estado-verde)] font-bold" aria-hidden="true">✓</div>
+        <h2 id="confirmacion-saip-titulo" class="text-xl font-semibold text-[var(--carbon)]">Solicitud SAIP registrada</h2>
+        <p class="text-sm text-[var(--niebla)] mt-1">Numero de expediente generado:</p>
+        <p class="mt-2 font-mono text-base font-bold text-[var(--peru-rojo)]">{{ expedienteGenerado() }}</p>
+        <p class="text-xs text-[var(--niebla)] mt-4 inline-flex items-center gap-2">
+          <span class="inline-block h-3.5 w-3.5 rounded-full border-2 border-[rgba(23,23,23,0.18)] border-t-[var(--peru-rojo)] animate-spin" aria-hidden="true"></span>
+          Sera redirigido a /ciudadano en 2 segundos...
+        </p>
+      </section>
+    </div>
+  }
 </main>

--- a/transparencia-frontend/src/app/pages/ciudadano/nueva-saip.component.ts
+++ b/transparencia-frontend/src/app/pages/ciudadano/nueva-saip.component.ts
@@ -1,6 +1,7 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  OnDestroy,
   PLATFORM_ID,
   computed,
   inject,
@@ -14,7 +15,7 @@ import {
   ValidatorFn,
   Validators,
 } from '@angular/forms';
-import { RouterLink } from '@angular/router';
+import { Router, RouterLink } from '@angular/router';
 import { EntidadService } from '../../services/entidad.service';
 import { SolicitudService } from '../../services/solicitud.service';
 import { Entidad } from '../../models/entidad.model';
@@ -50,17 +51,21 @@ const alMenosUnFormatoSeleccionado: ValidatorFn = (group) => {
   templateUrl: './nueva-saip.component.html',
   styleUrl: './nueva-saip.component.css',
 })
-export class NuevaSaipComponent {
+export class NuevaSaipComponent implements OnDestroy {
   private readonly fb = inject(FormBuilder);
   private readonly entidadService = inject(EntidadService);
   private readonly solicitudService = inject(SolicitudService);
   private readonly platformId = inject(PLATFORM_ID);
+  private readonly router = inject(Router);
+
+  private redirectTimeoutId: ReturnType<typeof setTimeout> | null = null;
 
   readonly entidades = signal<Entidad[]>([]);
   readonly loadingEntidades = signal(false);
   readonly submitting = signal(false);
   readonly error = signal<string | null>(null);
-  readonly success = signal<string | null>(null);
+  readonly confirmacionVisible = signal(false);
+  readonly expedienteGenerado = signal<string | null>(null);
   readonly adjuntos = signal<File[]>([]);
 
   readonly form = this.fb.group(
@@ -101,7 +106,8 @@ export class NuevaSaipComponent {
 
   onSubmit(): void {
     this.error.set(null);
-    this.success.set(null);
+    this.confirmacionVisible.set(false);
+    this.expedienteGenerado.set(null);
 
     if (this.form.invalid) {
       this.form.markAllAsTouched();
@@ -132,7 +138,8 @@ export class NuevaSaipComponent {
     this.solicitudService.crear(payload).subscribe({
       next: (solicitud) => {
         this.submitting.set(false);
-        this.success.set(`Solicitud registrada correctamente: ${solicitud.expediente}.`);
+        this.expedienteGenerado.set(solicitud.expediente);
+        this.confirmacionVisible.set(true);
         this.form.reset({
           entidadId: 0,
           asunto: '',
@@ -143,6 +150,7 @@ export class NuevaSaipComponent {
           copiaSimple: true,
           copiaCertificada: false,
         });
+        this.programarRedireccion();
       },
       error: (errorResponse) => {
         this.submitting.set(false);
@@ -178,5 +186,23 @@ export class NuevaSaipComponent {
     } catch {
       return null;
     }
+  }
+
+  ngOnDestroy(): void {
+    if (this.redirectTimeoutId) {
+      clearTimeout(this.redirectTimeoutId);
+      this.redirectTimeoutId = null;
+    }
+  }
+
+  private programarRedireccion(): void {
+    if (this.redirectTimeoutId) {
+      clearTimeout(this.redirectTimeoutId);
+    }
+
+    this.redirectTimeoutId = setTimeout(() => {
+      this.confirmacionVisible.set(false);
+      this.router.navigate(['/ciudadano']);
+    }, 2000);
   }
 }


### PR DESCRIPTION
## Contexto
Se implementa FE-03 de HU-02 para completar el flujo funcional de registro SAIP conectado al backend, incorporando retroalimentación de carga y confirmación al ciudadano tras el envío.

## Cambios incluidos
- Integración del submit de `NuevaSaipComponent` con `SolicitudService.crear()` y manejo de errores.
- Captura del expediente retornado por API y activación de confirmación visual.
- Redirección automática a `/ciudadano` tras 2 segundos.
- Alta de ruta `/ciudadano` para garantizar destino válido de redirección.
- Ajustes de plantilla/estilos para spinner de carga y modal de confirmación.

## Trazabilidad de sub-issues
- [x] `Refs #26` en commit `dd00307`.
- [x] `Closes #26` en commit `eb90850`.

## Validación
- Frontend tests: `npm test -- --watch=false` ✅ (6/6)
- Frontend build: `npm run build` ✅
- Rama sincronizada con `origin/develop` (sin commits ajenos en el delta del PR).

## Riesgos y mitigaciones
- Riesgo: dependencia de formato de expediente devuelto por backend para visualización en modal.
- Mitigación: se renderiza exactamente el valor de API y se mantiene manejo de error en submit para fallos de contrato.

## Checklist de revisión
- [x] Alcance FE-03 implementado según backlog
- [x] Commits atómicos por responsabilidad
- [x] Trazabilidad `Refs/Closes` del sub-issue
- [x] Tests y build en verde
- [x] Sin secretos ni artefactos sensibles en diff