### PR TITLE
🔀 test(HU-03): validar DiasHabilesUtil con pruebas unitarias

### DIFF
--- a/transparencia-backend/src/test/java/com/transparencia/api/util/DiasHabilesUtilTest.java
+++ b/transparencia-backend/src/test/java/com/transparencia/api/util/DiasHabilesUtilTest.java
@@ -1,0 +1,85 @@
+package com.transparencia.api.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
+
+class DiasHabilesUtilTest {
+
+    @Test
+    void esDiaHabil_debeRetornarFalseParaSabado() {
+        LocalDate sabado = LocalDate.of(2026, 4, 18);
+        assertFalse(DiasHabilesUtil.esDiaHabil(sabado));
+    }
+
+    @Test
+    void esDiaHabil_debeRetornarFalseParaFeriado() {
+        LocalDate fiestasPatrias = LocalDate.of(2026, 7, 28);
+        assertFalse(DiasHabilesUtil.esDiaHabil(fiestasPatrias));
+    }
+
+    @Test
+    void esDiaHabil_debeRetornarTrueParaDiaLaboralNoFeriado() {
+        LocalDate juevesLaboral = LocalDate.of(2026, 4, 16);
+        assertTrue(DiasHabilesUtil.esDiaHabil(juevesLaboral));
+    }
+
+    @Test
+    void esFeriado_debeDetectarFeriadoFijo() {
+        LocalDate navidad = LocalDate.of(2026, 12, 25);
+        assertTrue(DiasHabilesUtil.esFeriado(navidad));
+    }
+
+    @Test
+    void esFeriado_debeRetornarFalseCuandoNoEsFeriado() {
+        LocalDate fechaRegular = LocalDate.of(2026, 12, 24);
+        assertFalse(DiasHabilesUtil.esFeriado(fechaRegular));
+    }
+
+    @Test
+    void sumarDiasHabiles_debeSaltarFinDeSemana() {
+        LocalDate viernes = LocalDate.of(2026, 4, 17);
+        LocalDate resultado = DiasHabilesUtil.sumarDiasHabiles(viernes, 1);
+
+        assertEquals(LocalDate.of(2026, 4, 20), resultado);
+    }
+
+    @Test
+    void sumarDiasHabiles_debeSaltarFeriadosConsecutivos() {
+        LocalDate inicio = LocalDate.of(2026, 7, 27);
+        LocalDate resultado = DiasHabilesUtil.sumarDiasHabiles(inicio, 1);
+
+        assertEquals(LocalDate.of(2026, 7, 30), resultado);
+    }
+
+    @Test
+    void contarDiasHabiles_debeContarEnRangoAscendente() {
+        LocalDate desde = LocalDate.of(2026, 4, 13);
+        LocalDate hasta = LocalDate.of(2026, 4, 17);
+
+        assertEquals(5, DiasHabilesUtil.contarDiasHabiles(desde, hasta));
+    }
+
+    @Test
+    void contarDiasHabiles_debeRetornarNegativoEnRangoDescendente() {
+        LocalDate desde = LocalDate.of(2026, 4, 17);
+        LocalDate hasta = LocalDate.of(2026, 4, 13);
+
+        assertEquals(-5, DiasHabilesUtil.contarDiasHabiles(desde, hasta));
+    }
+
+    @Test
+    void diasHabilesRestantes_debeSerPositivoParaFechaFutura() {
+        LocalDate fechaFutura = LocalDate.now().plusDays(10);
+        assertTrue(DiasHabilesUtil.diasHabilesRestantes(fechaFutura) > 0);
+    }
+
+    @Test
+    void diasHabilesRestantes_debeSerNegativoParaFechaVencida() {
+        LocalDate fechaVencida = LocalDate.now().minusDays(10);
+        assertTrue(DiasHabilesUtil.diasHabilesRestantes(fechaVencida) < 0);
+    }
+}


### PR DESCRIPTION
## Contexto
HU-03 BE-01 define el utilitario de días hábiles con reglas de calendario peruano. La implementación del utilitario ya existía en el backend, por lo que este PR cierra la cobertura de pruebas para asegurar su comportamiento y prevenir regresiones en cálculo de plazos.

## Cambios incluidos
- Se agrega [transparencia-backend/src/test/java/com/transparencia/api/util/DiasHabilesUtilTest.java](transparencia-backend/src/test/java/com/transparencia/api/util/DiasHabilesUtilTest.java).
- Se cubren escenarios de:
  - `esDiaHabil` (sábado, feriado y día laboral).
  - `esFeriado` (feriado fijo y fecha regular).
  - `sumarDiasHabiles` (salto de fin de semana y feriados consecutivos).
  - `contarDiasHabiles` (rango ascendente y descendente).
  - `diasHabilesRestantes` (futuro y vencido).

## Trazabilidad de sub-issues
- [x] `Closes #28` — commit `5af69d0`.

## Validación
- Backend tests: `./mvnw.cmd test` ✅
  - Resultado: 46 tests, 0 fallos, 0 errores.
- Backend build: `./mvnw.cmd -DskipTests package` ✅
  - Resultado: `BUILD SUCCESS`.

## Riesgos y mitigaciones
- Riesgo: cambios futuros en reglas de feriados pueden invalidar expectativas actuales.
- Mitigación: los tests agregados detectan rápidamente cambios de comportamiento en cálculo de plazos.

## Checklist de revisión
- [x] Alcance limitado al sub-issue BE-01.
- [x] Commit atómico firmado con referencia de cierre.
- [x] Validación de tests y build backend en verde.
- [x] Sin cambios funcionales fuera del utilitario/pruebas.