### PR TITLE
🔀 feat(HU-03): BE-02 · automatizar deteccion de silencio administrativo

### DIFF
--- a/transparencia-backend/src/main/java/com/transparencia/api/TransparenciaBackendApplication.java
+++ b/transparencia-backend/src/main/java/com/transparencia/api/TransparenciaBackendApplication.java
@@ -2,8 +2,10 @@ package com.transparencia.api;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class TransparenciaBackendApplication {
 
     public static void main(String[] args) {

--- a/transparencia-backend/src/main/java/com/transparencia/api/service/SilencioAdministrativoScheduler.java
+++ b/transparencia-backend/src/main/java/com/transparencia/api/service/SilencioAdministrativoScheduler.java
@@ -1,0 +1,42 @@
+package com.transparencia.api.service;
+
+import java.time.Clock;
+import java.time.LocalDate;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.transparencia.api.util.DiasHabilesUtil;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+public class SilencioAdministrativoScheduler {
+
+    private final SolicitudService solicitudService;
+    private final Clock clock;
+
+    @Autowired
+    public SilencioAdministrativoScheduler(SolicitudService solicitudService) {
+        this(solicitudService, Clock.systemDefaultZone());
+    }
+
+    SilencioAdministrativoScheduler(SolicitudService solicitudService, Clock clock) {
+        this.solicitudService = solicitudService;
+        this.clock = clock;
+    }
+
+    @Scheduled(cron = "0 0 8 * * MON-FRI")
+    public void ejecutarDeteccion() {
+        LocalDate hoy = LocalDate.now(clock);
+        if (!DiasHabilesUtil.esDiaHabil(hoy)) {
+            log.info("Scheduler silencio administrativo omitido por dia no habil: {}", hoy);
+            return;
+        }
+
+        int totalVencidas = solicitudService.detectarSilencioAdministrativo();
+        log.info("Scheduler silencio administrativo ejecuto deteccion. Solicitudes marcadas VENCIDA: {}", totalVencidas);
+    }
+}

--- a/transparencia-backend/src/test/java/com/transparencia/api/service/SilencioAdministrativoSchedulerTest.java
+++ b/transparencia-backend/src/test/java/com/transparencia/api/service/SilencioAdministrativoSchedulerTest.java
@@ -1,0 +1,51 @@
+package com.transparencia.api.service;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SilencioAdministrativoSchedulerTest {
+
+    @Mock
+    private SolicitudService solicitudService;
+
+    @Test
+    void ejecutarDeteccionEnDiaHabilDebeInvocarServicio() {
+        Clock clock = Clock.fixed(Instant.parse("2026-04-15T13:00:00Z"), ZoneId.of("America/Lima"));
+        SilencioAdministrativoScheduler scheduler = new SilencioAdministrativoScheduler(solicitudService, clock);
+        when(solicitudService.detectarSilencioAdministrativo()).thenReturn(3);
+
+        scheduler.ejecutarDeteccion();
+
+        verify(solicitudService).detectarSilencioAdministrativo();
+    }
+
+    @Test
+    void ejecutarDeteccionEnSabadoNoDebeInvocarServicio() {
+        Clock clock = Clock.fixed(Instant.parse("2026-04-18T13:00:00Z"), ZoneId.of("America/Lima"));
+        SilencioAdministrativoScheduler scheduler = new SilencioAdministrativoScheduler(solicitudService, clock);
+
+        scheduler.ejecutarDeteccion();
+
+        verify(solicitudService, never()).detectarSilencioAdministrativo();
+    }
+
+    @Test
+    void ejecutarDeteccionEnFeriadoNoDebeInvocarServicio() {
+        Clock clock = Clock.fixed(Instant.parse("2026-07-28T13:00:00Z"), ZoneId.of("America/Lima"));
+        SilencioAdministrativoScheduler scheduler = new SilencioAdministrativoScheduler(solicitudService, clock);
+
+        scheduler.ejecutarDeteccion();
+
+        verify(solicitudService, never()).detectarSilencioAdministrativo();
+    }
+}


### PR DESCRIPTION
## Contexto
Se requiere ejecutar de forma automática la detección de solicitudes SAIP vencidas para aplicar silencio administrativo sin intervención manual, respetando calendario hábil peruano y dejando trazabilidad operativa en logs.

## Cambios incluidos
- Backend: se habilitó scheduling global en la aplicación para permitir tareas programadas.
- Backend: se agregó el componente `SilencioAdministrativoScheduler` con cron a las 08:00 AM de lunes a viernes.
- Backend: el scheduler valida día hábil con `DiasHabilesUtil` antes de invocar detección.
- Backend: se añadieron logs de ejecución y de omisión cuando la fecha no es hábil.
- Testing: se incorporaron pruebas unitarias del scheduler para día hábil, sábado y feriado nacional.

## Trazabilidad de sub-issues
- [x] Refs #29 en commit 72c03b0 (implementación scheduler + habilitación scheduling).
- [x] Closes #29 en commit 3d90094 (pruebas unitarias scheduler).

## Validación
- Backend tests: `./mvnw.cmd test` -> PASS (49 tests, 0 failures, 0 errors).
- Backend build: `./mvnw.cmd -DskipTests package` -> PASS.
- Verificación de atomicidad: `git log --oneline origin/develop..HEAD` contiene 2 commits atómicos de BE-02.

## Riesgos y mitigaciones
- Riesgo: ejecución en fechas no hábiles por configuración de calendario.
- Mitigación: guard clause con `DiasHabilesUtil.esDiaHabil(...)` y pruebas sobre sábado/feriado.
- Riesgo: regresiones en inicialización de contexto Spring por nuevo componente.
- Mitigación: constructor principal explícito para inyección y suite de seguridad ejecutada en verde.

## Checklist de revisión
- [ ] El cron y la validación de día hábil cumplen BR-SAIP-001/002.
- [ ] Los logs del scheduler son suficientes para monitoreo operativo.
- [ ] La cobertura del scheduler valida ejecución y no-ejecución.
- [ ] No se incluyeron cambios fuera del sub-issue BE-02.
