### PR TITLE
🔀 feat(HU-03): BE-03 · implementar endpoints de respuesta SAIP

### DIFF
--- a/transparencia-backend/src/main/java/com/transparencia/api/controller/RespuestaRestController.java
+++ b/transparencia-backend/src/main/java/com/transparencia/api/controller/RespuestaRestController.java
@@ -1,0 +1,97 @@
+package com.transparencia.api.controller;
+
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import com.transparencia.api.exception.RecursoNoEncontradoException;
+import com.transparencia.api.model.dto.CrearRespuestaRequest;
+import com.transparencia.api.model.dto.RespuestaDTO;
+import com.transparencia.api.model.entity.Respuesta;
+import com.transparencia.api.model.entity.Solicitud;
+import com.transparencia.api.service.RespuestaService;
+import com.transparencia.api.service.SolicitudService;
+
+import java.util.List;
+
+@RestController
+@Validated
+@RequestMapping("/api/respuestas")
+public class RespuestaRestController {
+
+    private final RespuestaService respuestaService;
+    private final SolicitudService solicitudService;
+
+    public RespuestaRestController(
+        RespuestaService respuestaService,
+        SolicitudService solicitudService
+    ) {
+        this.respuestaService = respuestaService;
+        this.solicitudService = solicitudService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<RespuestaDTO>> listar() {
+        List<RespuestaDTO> respuestas = respuestaService.obtenerTodasLasRespuestas()
+            .stream()
+            .map(RespuestaDTO::from)
+            .toList();
+        return ResponseEntity.ok(respuestas);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<RespuestaDTO> obtenerPorId(@PathVariable Long id) {
+        Respuesta respuesta = respuestaService.obtenerRespuestaPorId(id)
+            .orElseThrow(() -> new RecursoNoEncontradoException("Respuesta no encontrada con ID: " + id));
+        return ResponseEntity.ok(RespuestaDTO.from(respuesta));
+    }
+
+    @GetMapping("/solicitud/{solicitudId}")
+    public ResponseEntity<RespuestaDTO> obtenerPorSolicitud(@PathVariable Long solicitudId) {
+        Solicitud solicitud = solicitudService.obtenerSolicitudPorId(solicitudId)
+            .orElseThrow(() -> new RecursoNoEncontradoException("Solicitud no encontrada con ID: " + solicitudId));
+
+        if (solicitud.getRespuesta() == null) {
+            throw new RecursoNoEncontradoException("La solicitud no tiene respuesta");
+        }
+
+        return ResponseEntity.ok(RespuestaDTO.from(solicitud.getRespuesta()));
+    }
+
+    @PostMapping
+    public ResponseEntity<RespuestaDTO> crear(@Valid @RequestBody CrearRespuestaRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(respuestaService.crearRespuesta(request));
+    }
+
+    @PostMapping("/aceptar")
+    public ResponseEntity<RespuestaDTO> aceptarSolicitud(@Valid @RequestBody CrearRespuestaRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(respuestaService.aceptarSolicitud(request));
+    }
+
+    @PostMapping("/denegar")
+    public ResponseEntity<RespuestaDTO> denegarSolicitud(@Valid @RequestBody CrearRespuestaRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(respuestaService.denegarSolicitud(request));
+    }
+
+    @GetMapping("/causales-denegacion")
+    public ResponseEntity<List<String>> obtenerCausalesDenegacion() {
+        List<String> causales = List.of(
+            "Informacion Confidencial - Art. 15 Ley 27806",
+            "Informacion Secreta - Art. 15-A Ley 27806",
+            "Informacion Reservada - Art. 15-B Ley 27806",
+            "Informacion que afecta la intimidad personal",
+            "Informacion vinculada a investigaciones en tramite",
+            "Secreto bancario, tributario, comercial o tecnologico",
+            "Informacion elaborada como consejo o recomendacion",
+            "Informacion que ponga en riesgo la vida o seguridad de personas",
+            "La solicitud requiere una elaboracion de la informacion"
+        );
+        return ResponseEntity.ok(causales);
+    }
+}

--- a/transparencia-backend/src/main/java/com/transparencia/api/model/dto/CrearRespuestaRequest.java
+++ b/transparencia-backend/src/main/java/com/transparencia/api/model/dto/CrearRespuestaRequest.java
@@ -1,0 +1,34 @@
+package com.transparencia.api.model.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
+public record CrearRespuestaRequest(
+    @NotNull(message = "El ID de la solicitud es obligatorio")
+    Long solicitudId,
+
+    @NotNull(message = "El ID del funcionario es obligatorio")
+    Long funcionarioId,
+
+    @NotBlank(message = "El tipo de respuesta es obligatorio")
+    String tipoRespuesta,
+
+    @NotBlank(message = "El contenido es obligatorio")
+    @Size(max = 5000, message = "El contenido no puede exceder 5000 caracteres")
+    String contenido,
+
+    @Size(max = 500, message = "La causal denegatoria no puede exceder 500 caracteres")
+    String causalDenegatoria,
+
+    @Size(max = 2000, message = "El fundamento legal no puede exceder 2000 caracteres")
+    String fundamentoLegal,
+
+    @Size(max = 100, message = "El formato de entrega no puede exceder 100 caracteres")
+    String formatoEntrega,
+
+    @Positive(message = "El plazo de entrega debe ser mayor a cero")
+    Integer plazoEntrega
+) {
+}

--- a/transparencia-backend/src/main/java/com/transparencia/api/model/entity/Respuesta.java
+++ b/transparencia-backend/src/main/java/com/transparencia/api/model/entity/Respuesta.java
@@ -1,5 +1,6 @@
 package com.transparencia.api.model.entity;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -7,11 +8,14 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
+import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -23,7 +27,10 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-@Table(name = "respuestas")
+@Table(name = "respuestas", indexes = {
+    @Index(name = "idx_respuesta_solicitud", columnList = "id_solicitud"),
+    @Index(name = "idx_respuesta_funcionario", columnList = "id_funcionario")
+})
 public class Respuesta {
 
     @Id
@@ -31,35 +38,44 @@ public class Respuesta {
     @Column(name = "id_respuesta")
     private Long idRespuesta;
 
+    @NotNull(message = "La solicitud no puede ser nula")
+    @OneToOne
+    @JoinColumn(name = "id_solicitud", nullable = false, unique = true)
+    private Solicitud solicitud;
+
+    @NotNull(message = "El funcionario no puede ser nulo")
+    @ManyToOne
+    @JoinColumn(name = "id_funcionario", nullable = false)
+    private Funcionario funcionario;
+
     @Enumerated(EnumType.STRING)
-    @Column(name = "tipo_respuesta", length = 40)
+    @Column(name = "tipo_respuesta", length = 30)
     private TipoRespuesta tipoRespuesta;
 
-    @Column(length = 50)
+    @Column(length = 20)
     private String decision;
 
     @Column(columnDefinition = "TEXT")
     private String contenido;
 
-    @Column(name = "causal_denegatoria", length = 200)
+    @Column(name = "causal_denegatoria", length = 500)
     private String causalDenegatoria;
 
-    @Column(name = "fundamento_legal", length = 300)
+    @Column(name = "fundamento_legal", columnDefinition = "TEXT")
     private String fundamentoLegal;
 
-    @Column(name = "fecha_respuesta")
+    @Column(name = "fecha_respuesta", nullable = false)
     private LocalDateTime fechaRespuesta;
 
-    @ManyToOne
-    @JoinColumn(name = "id_funcionario")
-    private Funcionario funcionario;
-
-    @OneToOne
-    @JoinColumn(name = "id_solicitud")
-    private Solicitud solicitud;
-
-    @OneToMany(mappedBy = "respuesta")
+    @OneToMany(mappedBy = "respuesta", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
     private List<Documento> documentos;
+
+    @PrePersist
+    protected void onCreate() {
+        if (fechaRespuesta == null) {
+            fechaRespuesta = LocalDateTime.now();
+        }
+    }
 
     public enum TipoRespuesta {
         ENTREGA_TOTAL,

--- a/transparencia-backend/src/main/java/com/transparencia/api/repository/RespuestaRepository.java
+++ b/transparencia-backend/src/main/java/com/transparencia/api/repository/RespuestaRepository.java
@@ -1,0 +1,13 @@
+package com.transparencia.api.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import com.transparencia.api.model.entity.Respuesta;
+
+import java.util.Optional;
+
+@Repository
+public interface RespuestaRepository extends JpaRepository<Respuesta, Long> {
+
+    Optional<Respuesta> findBySolicitud_IdSolicitud(Long solicitudId);
+}

--- a/transparencia-backend/src/main/java/com/transparencia/api/service/RespuestaService.java
+++ b/transparencia-backend/src/main/java/com/transparencia/api/service/RespuestaService.java
@@ -1,0 +1,182 @@
+package com.transparencia.api.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import com.transparencia.api.exception.RecursoNoEncontradoException;
+import com.transparencia.api.model.dto.CrearRespuestaRequest;
+import com.transparencia.api.model.dto.RespuestaDTO;
+import com.transparencia.api.model.entity.Funcionario;
+import com.transparencia.api.model.entity.Respuesta;
+import com.transparencia.api.model.entity.Solicitud;
+import com.transparencia.api.repository.RespuestaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+@Service
+public class RespuestaService {
+
+    private final RespuestaRepository respuestaRepository;
+    private final SolicitudService solicitudService;
+    private final FuncionarioService funcionarioService;
+
+    public RespuestaService(
+        RespuestaRepository respuestaRepository,
+        SolicitudService solicitudService,
+        FuncionarioService funcionarioService
+    ) {
+        this.respuestaRepository = respuestaRepository;
+        this.solicitudService = solicitudService;
+        this.funcionarioService = funcionarioService;
+    }
+
+    @Transactional(readOnly = true)
+    public List<Respuesta> obtenerTodasLasRespuestas() {
+        return respuestaRepository.findAll();
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<Respuesta> obtenerRespuestaPorId(Long id) {
+        return respuestaRepository.findById(id);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<Respuesta> obtenerRespuestaPorSolicitud(Long solicitudId) {
+        return respuestaRepository.findBySolicitud_IdSolicitud(solicitudId);
+    }
+
+    @Transactional
+    public RespuestaDTO crearRespuesta(CrearRespuestaRequest request) {
+        Solicitud solicitud = buscarSolicitud(request.solicitudId());
+        validarSinRespuesta(solicitud);
+        Funcionario funcionario = buscarFuncionario(request.funcionarioId());
+
+        Respuesta respuesta = new Respuesta();
+        respuesta.setSolicitud(solicitud);
+        respuesta.setFuncionario(funcionario);
+        respuesta.setContenido(request.contenido().trim());
+        respuesta.setFechaRespuesta(LocalDateTime.now());
+
+        aplicarTipoRespuesta(respuesta, solicitud, request);
+        persistirRespuestaYSolicitud(solicitud, respuesta);
+        return RespuestaDTO.from(respuesta);
+    }
+
+    @Transactional
+    public RespuestaDTO aceptarSolicitud(CrearRespuestaRequest request) {
+        Solicitud solicitud = buscarSolicitud(request.solicitudId());
+        validarSinRespuesta(solicitud);
+        Funcionario funcionario = buscarFuncionario(request.funcionarioId());
+
+        Respuesta respuesta = new Respuesta();
+        respuesta.setSolicitud(solicitud);
+        respuesta.setFuncionario(funcionario);
+        respuesta.setTipoRespuesta(Respuesta.TipoRespuesta.ENTREGA_TOTAL);
+        respuesta.setDecision("aceptar");
+        respuesta.setContenido(construirContenidoAceptacion(request));
+        respuesta.setFechaRespuesta(LocalDateTime.now());
+
+        solicitud.setEstado(Solicitud.EstadoSolicitud.RESPONDIDA);
+        persistirRespuestaYSolicitud(solicitud, respuesta);
+        return RespuestaDTO.from(respuesta);
+    }
+
+    @Transactional
+    public RespuestaDTO denegarSolicitud(CrearRespuestaRequest request) {
+        Solicitud solicitud = buscarSolicitud(request.solicitudId());
+        validarSinRespuesta(solicitud);
+        Funcionario funcionario = buscarFuncionario(request.funcionarioId());
+        validarDenegacion(request);
+
+        Respuesta respuesta = new Respuesta();
+        respuesta.setSolicitud(solicitud);
+        respuesta.setFuncionario(funcionario);
+        respuesta.setTipoRespuesta(Respuesta.TipoRespuesta.DENEGACION_TOTAL);
+        respuesta.setDecision("denegar");
+        respuesta.setContenido(request.contenido().trim());
+        respuesta.setCausalDenegatoria(request.causalDenegatoria().trim());
+        respuesta.setFundamentoLegal(trimToNull(request.fundamentoLegal()));
+        respuesta.setFechaRespuesta(LocalDateTime.now());
+
+        solicitud.setEstado(Solicitud.EstadoSolicitud.DENEGADA);
+        persistirRespuestaYSolicitud(solicitud, respuesta);
+        return RespuestaDTO.from(respuesta);
+    }
+
+    private void aplicarTipoRespuesta(Respuesta respuesta, Solicitud solicitud, CrearRespuestaRequest request) {
+        String tipo = request.tipoRespuesta().trim().toUpperCase(Locale.ROOT);
+        switch (tipo) {
+            case "SILENCIO_ADMINISTRATIVO" -> throw new IllegalArgumentException(
+                "Silencio administrativo se aplica automaticamente y no se registra manualmente"
+            );
+            case "ENTREGA_TOTAL", "ACEPTADA" -> {
+                respuesta.setTipoRespuesta(Respuesta.TipoRespuesta.ENTREGA_TOTAL);
+                respuesta.setDecision("aceptar");
+                solicitud.setEstado(Solicitud.EstadoSolicitud.RESPONDIDA);
+            }
+            case "ENTREGA_PARCIAL" -> {
+                respuesta.setTipoRespuesta(Respuesta.TipoRespuesta.ENTREGA_PARCIAL);
+                respuesta.setDecision("aceptar");
+                solicitud.setEstado(Solicitud.EstadoSolicitud.RESPONDIDA);
+            }
+            case "DENEGACION_TOTAL", "DENEGADA" -> {
+                validarDenegacion(request);
+                respuesta.setTipoRespuesta(Respuesta.TipoRespuesta.DENEGACION_TOTAL);
+                respuesta.setDecision("denegar");
+                respuesta.setCausalDenegatoria(request.causalDenegatoria().trim());
+                respuesta.setFundamentoLegal(trimToNull(request.fundamentoLegal()));
+                solicitud.setEstado(Solicitud.EstadoSolicitud.DENEGADA);
+            }
+            default -> throw new IllegalArgumentException("Tipo de respuesta no valido: " + request.tipoRespuesta());
+        }
+    }
+
+    private Solicitud buscarSolicitud(Long solicitudId) {
+        return solicitudService.obtenerSolicitudPorId(solicitudId)
+            .orElseThrow(() -> new RecursoNoEncontradoException("Solicitud no encontrada con ID: " + solicitudId));
+    }
+
+    private Funcionario buscarFuncionario(Long funcionarioId) {
+        return funcionarioService.obtenerFuncionarioPorId(funcionarioId)
+            .orElseThrow(() -> new RecursoNoEncontradoException("Funcionario no encontrado con ID: " + funcionarioId));
+    }
+
+    private void validarSinRespuesta(Solicitud solicitud) {
+        if (solicitud.getRespuesta() != null) {
+            throw new IllegalArgumentException("La solicitud ya tiene una respuesta");
+        }
+    }
+
+    private void validarDenegacion(CrearRespuestaRequest request) {
+        if (!StringUtils.hasText(request.causalDenegatoria())) {
+            throw new IllegalArgumentException("La causal denegatoria es obligatoria para denegacion total");
+        }
+    }
+
+    private void persistirRespuestaYSolicitud(Solicitud solicitud, Respuesta respuesta) {
+        respuestaRepository.save(respuesta);
+        solicitud.setRespuesta(respuesta);
+        solicitudService.save(solicitud);
+    }
+
+    private String construirContenidoAceptacion(CrearRespuestaRequest request) {
+        StringBuilder contenido = new StringBuilder(request.contenido().trim());
+        if (StringUtils.hasText(request.formatoEntrega())) {
+            contenido.append("\n\nFormato de entrega: ").append(request.formatoEntrega().trim());
+        }
+        if (request.plazoEntrega() != null) {
+            contenido.append("\nPlazo estimado: ").append(request.plazoEntrega()).append(" dias habiles");
+        }
+        return contenido.toString();
+    }
+
+    private String trimToNull(String value) {
+        if (!StringUtils.hasText(value)) {
+            return null;
+        }
+        return value.trim();
+    }
+}


### PR DESCRIPTION
## Contexto
Se implementa el sub-issue BE-03 de HU-03 para permitir que el funcionario registre respuestas SAIP (aceptación, denegación y creación genérica) bajo el flujo de negocio del backlog, incluyendo causales de denegación y validaciones de integridad.

Referencia aplicada:
- `github_repo` no disponible por índice.
- Se usó fallback obligatorio en ruta local guía `D:/PROYECTOS-CIBERTEC/PROYECTO-DE-TESIS-SAIP-Y-APELACIONES/plataforma-saip-apelaciones` para replicar patrones de `RespuestaService` y `RespuestaRestController`.

## Cambios incluidos
- Entidad: ajuste de `Respuesta` con índices, relaciones obligatorias (`solicitud` única y `funcionario`), longitudes de campos y `@PrePersist` para fecha.
- DTO: nuevo `CrearRespuestaRequest` con validaciones Jakarta.
- Repository: nuevo `RespuestaRepository` con `findBySolicitud_IdSolicitud`.
- Service: nuevo `RespuestaService` con `crearRespuesta`, `aceptarSolicitud`, `denegarSolicitud`, `aplicarTipoRespuesta`, validación de respuesta previa y bloqueo de `SILENCIO_ADMINISTRATIVO` manual.
- Controller: nuevo `RespuestaRestController` con endpoints:
  - `GET /api/respuestas`
  - `GET /api/respuestas/{id}`
  - `GET /api/respuestas/solicitud/{solicitudId}`
  - `POST /api/respuestas`
  - `POST /api/respuestas/aceptar`
  - `POST /api/respuestas/denegar`
  - `GET /api/respuestas/causales-denegacion`

## Trazabilidad de sub-issues
- [x] Refs #30 en `7c8f79b` (base de dominio y datos para respuestas SAIP).
- [x] Closes #30 en `55e25c3` (servicio y endpoints REST de respuesta).

## Validación
- Backend tests: `mvnw.cmd test` -> PASS (49 tests, 0 failures, 0 errors).
- Backend build: `mvnw.cmd -DskipTests package` -> PASS.
- Atomicidad validada con `git log --oneline origin/develop..HEAD` -> 2 commits atómicos de BE-03.

## Riesgos y mitigaciones
- Riesgo: solicitudes con respuesta previa podrían duplicar registro.
- Mitigación: `validarSinRespuesta(...)` bloquea segunda respuesta.
- Riesgo: registro manual indebido de silencio administrativo.
- Mitigación: validación explícita en `aplicarTipoRespuesta(...)` que rechaza `SILENCIO_ADMINISTRATIVO` manual.
- Riesgo residual: cobertura específica de `RespuestaService` aún pendiente.
- Mitigación planificada: sub-issue BE-04 incorpora pruebas unitarias dedicadas.

## Checklist de revisión
- [ ] Endpoints `/api/respuestas` responden según contratos esperados.
- [ ] Estados de solicitud cambian correctamente a `RESPONDIDA`/`DENEGADA`.
- [ ] Rechazo de `SILENCIO_ADMINISTRATIVO` manual validado.
- [ ] Causales de denegación devuelven 9 opciones del Art. 15.
- [ ] No hay cambios fuera del alcance de BE-03.
