### PR TITLE
🔀 feat(HU-01): FE-01 · Maquetar Login y Registro

### DIFF
--- a/transparencia-frontend/src/app/app.routes.ts
+++ b/transparencia-frontend/src/app/app.routes.ts
@@ -1,5 +1,30 @@
 import { Routes } from '@angular/router';
+
 export const routes: Routes = [
+	{
+		path: 'login',
+		loadComponent: () => import('./pages/auth/login.component').then(m => m.LoginComponent),
+		data: { accessMode: 'citizen' }
+	},
+	{
+		path: 'acceso-funcionario',
+		loadComponent: () => import('./pages/auth/login.component').then(m => m.LoginComponent),
+		data: { accessMode: 'internal', requiredRole: 'FUNCIONARIO' }
+	},
+	{
+		path: 'acceso-ttaip',
+		loadComponent: () => import('./pages/auth/login.component').then(m => m.LoginComponent),
+		data: { accessMode: 'internal', requiredRole: 'TTAIP' }
+	},
+	{
+		path: 'acceso-admin',
+		loadComponent: () => import('./pages/auth/login.component').then(m => m.LoginComponent),
+		data: { accessMode: 'internal', requiredRole: 'ADMINISTRADOR' }
+	},
+	{
+		path: 'registro',
+		loadComponent: () => import('./pages/auth/registro.component').then(m => m.RegistroComponent)
+	},
   {
     path: 'ciudadano',
     redirectTo: 'ciudadano/nueva-saip',

--- a/transparencia-frontend/src/app/models/usuario.model.ts
+++ b/transparencia-frontend/src/app/models/usuario.model.ts
@@ -1,0 +1,40 @@
+export type TipoUsuario = 'CIUDADANO' | 'FUNCIONARIO' | 'TTAIP' | 'ADMINISTRADOR';
+
+export interface LoginRequest {
+  identificador: string;
+  password: string;
+}
+
+export interface LoginResponse {
+  success: boolean;
+  mensaje?: string;
+  token?: string;
+  usuarioId?: number;
+  email?: string;
+  tipoUsuario?: TipoUsuario | string;
+  nombre?: string;
+  dni?: string;
+  ciudadanoId?: number;
+  funcionarioId?: number;
+  entidadId?: number;
+  entidadNombre?: string;
+  miembroId?: number;
+  administradorId?: number;
+  redirectUrl?: string;
+}
+
+export interface RegistroRequest {
+  email: string;
+  password: string;
+  dni: string;
+  nombreCompleto: string;
+  telefono?: string;
+  direccion?: string;
+}
+
+export interface RegistroResponse {
+  success: boolean;
+  mensaje?: string;
+  ciudadanoId?: number;
+  email?: string;
+}

--- a/transparencia-frontend/src/app/pages/auth/login.component.css
+++ b/transparencia-frontend/src/app/pages/auth/login.component.css
@@ -129,6 +129,12 @@ input:focus {
   color: #991b1b;
 }
 
+.alert.success {
+  background: #ecfdf5;
+  border: 1px solid #a7f3d0;
+  color: #047857;
+}
+
 .btn-primary {
   border: 0;
   border-radius: 0.85rem;

--- a/transparencia-frontend/src/app/pages/auth/login.component.css
+++ b/transparencia-frontend/src/app/pages/auth/login.component.css
@@ -1,0 +1,210 @@
+:host {
+  display: block;
+}
+
+.auth-layout {
+  min-height: 100dvh;
+  display: grid;
+  place-items: center;
+  padding: 1.5rem;
+  background: radial-gradient(circle at 20% 20%, #ffe6eb 0%, transparent 32%),
+    radial-gradient(circle at 80% 10%, #e4efff 0%, transparent 28%),
+    linear-gradient(155deg, #f7f9ff 0%, #fff8f0 100%);
+  position: relative;
+  overflow: hidden;
+}
+
+.glow {
+  position: absolute;
+  width: 22rem;
+  height: 22rem;
+  border-radius: 50%;
+  filter: blur(42px);
+  opacity: 0.42;
+  z-index: 0;
+}
+
+.glow-left {
+  left: -8rem;
+  bottom: -6rem;
+  background: #d72d4f;
+}
+
+.glow-right {
+  right: -6rem;
+  top: -8rem;
+  background: #1d4ed8;
+}
+
+.auth-card {
+  width: min(30rem, 100%);
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.7);
+  backdrop-filter: blur(10px);
+  border-radius: 1.2rem;
+  box-shadow: 0 30px 70px -40px rgba(17, 24, 39, 0.7);
+  padding: 1.6rem;
+  z-index: 1;
+}
+
+.auth-header {
+  margin-bottom: 1.4rem;
+}
+
+.eyebrow {
+  margin: 0;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  color: #9a1f4d;
+  font-weight: 700;
+}
+
+.auth-header h1 {
+  margin: 0.4rem 0;
+  font-size: clamp(1.4rem, 2.6vw, 1.8rem);
+  color: #171a2b;
+}
+
+.subtitle {
+  margin: 0;
+  color: #4a4f63;
+  line-height: 1.4;
+  font-size: 0.95rem;
+}
+
+.auth-form {
+  display: grid;
+  gap: 1rem;
+}
+
+.form-row {
+  display: grid;
+  gap: 0.4rem;
+}
+
+label {
+  color: #23283b;
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+input {
+  border: 1px solid #ccd3e0;
+  background: #fefefe;
+  border-radius: 0.8rem;
+  height: 2.85rem;
+  padding: 0 0.9rem;
+  font-size: 0.97rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus {
+  outline: none;
+  border-color: #9a1f4d;
+  box-shadow: 0 0 0 3px rgba(154, 31, 77, 0.14);
+}
+
+.hint {
+  color: #5f6478;
+  font-size: 0.8rem;
+}
+
+.field-error {
+  margin: 0;
+  color: #b91c1c;
+  font-size: 0.82rem;
+}
+
+.alert {
+  margin: 0;
+  border-radius: 0.75rem;
+  padding: 0.75rem 0.85rem;
+  font-size: 0.9rem;
+}
+
+.alert.error {
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  color: #991b1b;
+}
+
+.btn-primary {
+  border: 0;
+  border-radius: 0.85rem;
+  height: 2.95rem;
+  background: linear-gradient(90deg, #b21d42, #d42f4f);
+  color: #fff;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 14px 22px -15px rgba(178, 29, 66, 0.9);
+}
+
+.btn-primary:hover:not(:disabled) {
+  transform: translateY(-1px);
+}
+
+.btn-primary:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.auth-links {
+  text-align: center;
+  font-size: 0.88rem;
+  color: #454b61;
+  display: grid;
+  gap: 0.25rem;
+}
+
+.auth-links a,
+.role-switcher a {
+  color: #0f3ea8;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.auth-links a:hover,
+.role-switcher a:hover {
+  text-decoration: underline;
+}
+
+.role-switcher {
+  margin-top: 1.2rem;
+  padding-top: 0.95rem;
+  border-top: 1px solid #e5e9f2;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.role-switcher p {
+  margin: 0;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: #5f6478;
+  font-weight: 700;
+}
+
+.role-switcher nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+}
+
+@media (max-width: 520px) {
+  .auth-layout {
+    padding: 1rem;
+  }
+
+  .auth-card {
+    padding: 1.25rem;
+  }
+
+  .role-switcher nav {
+    gap: 0.55rem;
+    font-size: 0.85rem;
+  }
+}

--- a/transparencia-frontend/src/app/pages/auth/login.component.html
+++ b/transparencia-frontend/src/app/pages/auth/login.component.html
@@ -1,0 +1,72 @@
+<section class="auth-layout">
+  <div class="glow glow-left" aria-hidden="true"></div>
+  <div class="glow glow-right" aria-hidden="true"></div>
+
+  <article class="auth-card">
+    <header class="auth-header">
+      <p class="eyebrow">SAIP · Acceso</p>
+      <h1>Iniciar sesión</h1>
+      <p class="subtitle" *ngIf="accessMode() === 'citizen'">
+        Ingrese con DNI y contraseña para presentar su solicitud de acceso.
+      </p>
+      <p class="subtitle" *ngIf="accessMode() === 'internal'">
+        Ingreso interno habilitado para perfil {{ requiredRoleLabel() }}.
+      </p>
+    </header>
+
+    <form class="auth-form" [formGroup]="form" (ngSubmit)="onSubmit()" novalidate>
+      <div class="form-row">
+        <label for="identificador">{{ identificadorLabel() }}</label>
+        <input
+          #identificadorInput
+          id="identificador"
+          formControlName="identificador"
+          [attr.maxlength]="accessMode() === 'citizen' ? 8 : null"
+          [attr.inputmode]="accessMode() === 'citizen' ? 'numeric' : 'email'"
+          [type]="accessMode() === 'internal' ? 'email' : 'text'"
+          autocomplete="username"
+          [placeholder]="identificadorPlaceholder()"
+          (input)="onIdentificadorInput(identificadorInput.value)"
+        />
+        <small class="hint" *ngIf="accessMode() === 'citizen'">Solo números, 8 dígitos.</small>
+        <p class="field-error" *ngIf="identificadorError()">{{ identificadorError() }}</p>
+      </div>
+
+      <div class="form-row">
+        <label for="password">Contraseña</label>
+        <input
+          id="password"
+          type="password"
+          formControlName="password"
+          autocomplete="current-password"
+          placeholder="Ingrese su contraseña"
+        />
+        <p class="field-error" *ngIf="passwordError()">{{ passwordError() }}</p>
+      </div>
+
+      <p class="alert error" *ngIf="errorMessage()">{{ errorMessage() }}</p>
+
+      <button type="submit" class="btn-primary" [disabled]="loading()">
+        {{ loading() ? 'Validando acceso...' : 'Ingresar' }}
+      </button>
+
+      <div class="auth-links" *ngIf="accessMode() === 'citizen'">
+        <span>¿Primera vez en SAIP?</span>
+        <a routerLink="/registro">Registrarse como ciudadano</a>
+      </div>
+
+      <div class="auth-links" *ngIf="accessMode() === 'internal'">
+        <a routerLink="/login">Volver al acceso ciudadano</a>
+      </div>
+    </form>
+
+    <footer class="role-switcher">
+      <p>Accesos internos</p>
+      <nav>
+        <a routerLink="/acceso-funcionario">Funcionario</a>
+        <a routerLink="/acceso-ttaip">TTAIP</a>
+        <a routerLink="/acceso-admin">Administrador</a>
+      </nav>
+    </footer>
+  </article>
+</section>

--- a/transparencia-frontend/src/app/pages/auth/login.component.html
+++ b/transparencia-frontend/src/app/pages/auth/login.component.html
@@ -44,6 +44,8 @@
         <p class="field-error" *ngIf="passwordError()">{{ passwordError() }}</p>
       </div>
 
+      <p class="alert success" *ngIf="successMessage()">{{ successMessage() }}</p>
+
       <p class="alert error" *ngIf="errorMessage()">{{ errorMessage() }}</p>
 
       <button type="submit" class="btn-primary" [disabled]="loading()">

--- a/transparencia-frontend/src/app/pages/auth/login.component.ts
+++ b/transparencia-frontend/src/app/pages/auth/login.component.ts
@@ -1,0 +1,242 @@
+import { CommonModule } from '@angular/common';
+import { ChangeDetectionStrategy, Component, OnInit, inject, signal } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { AuthService } from '../../services/auth.service';
+import { LoginRequest, LoginResponse, TipoUsuario } from '../../models/usuario.model';
+
+type AccessMode = 'citizen' | 'internal';
+
+@Component({
+  selector: 'app-login',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [CommonModule, ReactiveFormsModule, RouterLink],
+  templateUrl: './login.component.html',
+  styleUrl: './login.component.css'
+})
+export class LoginComponent implements OnInit {
+  private readonly authService = inject(AuthService);
+  private readonly router = inject(Router);
+  private readonly route = inject(ActivatedRoute);
+  private readonly formBuilder = inject(FormBuilder);
+
+  readonly form = this.formBuilder.nonNullable.group({
+    identificador: ['', [Validators.required]],
+    password: ['', [Validators.required]]
+  });
+
+  readonly loading = signal(false);
+  readonly errorMessage = signal('');
+  readonly accessMode = signal<AccessMode>('citizen');
+  readonly requiredRole = signal<TipoUsuario | null>(null);
+
+  ngOnInit(): void {
+    const data = this.route.snapshot.data as Partial<{ accessMode: AccessMode; requiredRole: TipoUsuario }>;
+
+    this.accessMode.set(data.accessMode === 'internal' ? 'internal' : 'citizen');
+    this.requiredRole.set(data.requiredRole ?? null);
+
+    this.configureIdentificadorValidators();
+    this.redirectIfSessionMatchesRoute();
+  }
+
+  get identificadorControl() {
+    return this.form.controls.identificador;
+  }
+
+  get passwordControl() {
+    return this.form.controls.password;
+  }
+
+  identificadorLabel(): string {
+    return this.accessMode() === 'citizen' ? 'DNI' : 'Correo institucional';
+  }
+
+  identificadorPlaceholder(): string {
+    return this.accessMode() === 'citizen' ? 'Ingrese su DNI (8 dígitos)' : 'usuario@institucion.gob.pe';
+  }
+
+  requiredRoleLabel(): string {
+    const role = this.requiredRole();
+
+    switch (role) {
+      case 'FUNCIONARIO':
+        return 'Funcionario';
+      case 'TTAIP':
+        return 'Miembro TTAIP';
+      case 'ADMINISTRADOR':
+        return 'Administrador';
+      default:
+        return 'Usuario interno';
+    }
+  }
+
+  onIdentificadorInput(value: string): void {
+    if (this.accessMode() !== 'citizen') {
+      return;
+    }
+
+    const cleaned = value.replace(/\D/g, '').slice(0, 8);
+    this.identificadorControl.setValue(cleaned, { emitEvent: false });
+  }
+
+  identificadorError(): string {
+    if (!this.identificadorControl.touched) {
+      return '';
+    }
+
+    if (this.identificadorControl.hasError('required')) {
+      return 'El identificador es obligatorio.';
+    }
+
+    if (this.accessMode() === 'citizen' && this.identificadorControl.hasError('pattern')) {
+      return 'El DNI debe contener exactamente 8 dígitos.';
+    }
+
+    if (this.accessMode() === 'internal' && this.identificadorControl.hasError('email')) {
+      return 'Ingrese un correo válido.';
+    }
+
+    return '';
+  }
+
+  passwordError(): string {
+    if (!this.passwordControl.touched) {
+      return '';
+    }
+
+    if (this.passwordControl.hasError('required')) {
+      return 'La contraseña es obligatoria.';
+    }
+
+    return '';
+  }
+
+  onSubmit(): void {
+    this.errorMessage.set('');
+
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+
+    const credentials: LoginRequest = this.form.getRawValue();
+
+    this.loading.set(true);
+
+    this.authService.login(credentials).subscribe({
+      next: (response) => {
+        this.loading.set(false);
+
+        if (!response.success || !response.token) {
+          this.errorMessage.set(response.mensaje ?? 'No se pudo iniciar sesión.');
+          return;
+        }
+
+        const role = this.toRole(response.tipoUsuario);
+        const expectedRole = this.requiredRole();
+
+        if (expectedRole && role !== expectedRole) {
+          this.errorMessage.set(`Este acceso es exclusivo para perfil ${this.requiredRoleLabel()}.`);
+          this.authService.cerrarSesion();
+          return;
+        }
+
+        this.authService.guardarSesion(response);
+        void this.router.navigateByUrl(this.resolveTargetRoute(response, role));
+      },
+      error: (error: unknown) => {
+        this.loading.set(false);
+        this.errorMessage.set(this.extractErrorMessage(error));
+      }
+    });
+  }
+
+  private configureIdentificadorValidators(): void {
+    if (this.accessMode() === 'citizen') {
+      this.identificadorControl.setValidators([
+        Validators.required,
+        Validators.pattern(/^\d{8}$/)
+      ]);
+    } else {
+      this.identificadorControl.setValidators([
+        Validators.required,
+        Validators.email
+      ]);
+    }
+
+    this.identificadorControl.updateValueAndValidity({ emitEvent: false });
+  }
+
+  private redirectIfSessionMatchesRoute(): void {
+    const sesion = this.authService.obtenerSesion();
+
+    if (!sesion?.token) {
+      return;
+    }
+
+    const role = this.toRole(sesion.tipoUsuario);
+    const expectedRole = this.requiredRole();
+
+    if (expectedRole && role !== expectedRole) {
+      return;
+    }
+
+    void this.router.navigateByUrl(this.resolveTargetRoute(sesion, role));
+  }
+
+  private resolveTargetRoute(response: LoginResponse, role: TipoUsuario | null): string {
+    const backendRouteMap: Record<string, string> = {
+      '/ciudadano/dashboard': '/ciudadano',
+      '/entidad/dashboard': '/funcionario',
+      '/ttaip/dashboard': '/ttaip',
+      '/admin/dashboard': '/admin'
+    };
+
+    if (response.redirectUrl && backendRouteMap[response.redirectUrl]) {
+      return backendRouteMap[response.redirectUrl];
+    }
+
+    const roleRouteMap: Record<TipoUsuario, string> = {
+      CIUDADANO: '/ciudadano',
+      FUNCIONARIO: '/funcionario',
+      TTAIP: '/ttaip',
+      ADMINISTRADOR: '/admin'
+    };
+
+    if (role) {
+      return roleRouteMap[role];
+    }
+
+    return '/login';
+  }
+
+  private toRole(value: string | TipoUsuario | undefined): TipoUsuario | null {
+    if (!value) {
+      return null;
+    }
+
+    const normalized = String(value).toUpperCase();
+
+    switch (normalized) {
+      case 'CIUDADANO':
+      case 'FUNCIONARIO':
+      case 'TTAIP':
+      case 'ADMINISTRADOR':
+        return normalized;
+      default:
+        return null;
+    }
+  }
+
+  private extractErrorMessage(error: unknown): string {
+    if (typeof error === 'object' && error !== null && 'error' in error) {
+      const payload = (error as { error?: { mensaje?: string } }).error;
+      if (payload?.mensaje) {
+        return payload.mensaje;
+      }
+    }
+
+    return 'Credenciales inválidas o servicio no disponible.';
+  }
+}

--- a/transparencia-frontend/src/app/pages/auth/login.component.ts
+++ b/transparencia-frontend/src/app/pages/auth/login.component.ts
@@ -27,6 +27,7 @@ export class LoginComponent implements OnInit {
 
   readonly loading = signal(false);
   readonly errorMessage = signal('');
+  readonly successMessage = signal('');
   readonly accessMode = signal<AccessMode>('citizen');
   readonly requiredRole = signal<TipoUsuario | null>(null);
 
@@ -37,6 +38,11 @@ export class LoginComponent implements OnInit {
     this.requiredRole.set(data.requiredRole ?? null);
 
     this.configureIdentificadorValidators();
+
+    if (this.route.snapshot.queryParamMap.get('registered') === '1') {
+      this.successMessage.set('Registro exitoso. Inicie sesión para continuar.');
+    }
+
     this.redirectIfSessionMatchesRoute();
   }
 
@@ -114,6 +120,7 @@ export class LoginComponent implements OnInit {
 
   onSubmit(): void {
     this.errorMessage.set('');
+    this.successMessage.set('');
 
     if (this.form.invalid) {
       this.form.markAllAsTouched();

--- a/transparencia-frontend/src/app/pages/auth/registro.component.css
+++ b/transparencia-frontend/src/app/pages/auth/registro.component.css
@@ -1,0 +1,239 @@
+:host {
+  display: block;
+}
+
+.registro-layout {
+  min-height: 100dvh;
+  display: grid;
+  place-items: center;
+  padding: 1.5rem;
+  background: radial-gradient(circle at 15% 18%, #e8fff5 0%, transparent 26%),
+    radial-gradient(circle at 85% 14%, #ffe8ef 0%, transparent 30%),
+    linear-gradient(165deg, #f5f8ff 0%, #fffaf3 100%);
+  position: relative;
+  overflow: hidden;
+}
+
+.shape {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(40px);
+  opacity: 0.35;
+  z-index: 0;
+}
+
+.shape-top {
+  width: 20rem;
+  height: 20rem;
+  background: #1d4ed8;
+  top: -8rem;
+  right: -7rem;
+}
+
+.shape-bottom {
+  width: 19rem;
+  height: 19rem;
+  background: #be123c;
+  bottom: -7rem;
+  left: -8rem;
+}
+
+.registro-card {
+  width: min(38rem, 100%);
+  background: rgba(255, 255, 255, 0.93);
+  border: 1px solid rgba(255, 255, 255, 0.7);
+  backdrop-filter: blur(8px);
+  border-radius: 1.2rem;
+  box-shadow: 0 32px 65px -42px rgba(17, 24, 39, 0.8);
+  padding: 1.55rem;
+  z-index: 1;
+}
+
+header {
+  margin-bottom: 1rem;
+}
+
+.eyebrow {
+  margin: 0;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  color: #b51a45;
+  font-weight: 700;
+}
+
+header h1 {
+  margin: 0.4rem 0 0.3rem;
+  font-size: clamp(1.35rem, 2.4vw, 1.75rem);
+  color: #171a2b;
+}
+
+header p {
+  margin: 0;
+  color: #4a4f63;
+}
+
+.wizard-indicator {
+  display: flex;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.wizard-indicator span {
+  flex: 1;
+  padding: 0.5rem 0.7rem;
+  border-radius: 999px;
+  text-align: center;
+  font-size: 0.78rem;
+  font-weight: 700;
+  background: #edf0f6;
+  color: #5f6478;
+  transition: all 0.2s ease;
+}
+
+.wizard-indicator span.active {
+  background: #be123c;
+  color: #fff;
+}
+
+form {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.form-row {
+  display: grid;
+  gap: 0.38rem;
+}
+
+label {
+  color: #23283b;
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+input {
+  border: 1px solid #ccd3e0;
+  background: #fff;
+  border-radius: 0.8rem;
+  min-height: 2.8rem;
+  padding: 0 0.9rem;
+  font-size: 0.96rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus {
+  outline: none;
+  border-color: #be123c;
+  box-shadow: 0 0 0 3px rgba(190, 18, 60, 0.13);
+}
+
+.password-rules {
+  margin: 0.2rem 0 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.25rem;
+}
+
+.password-rules li {
+  font-size: 0.79rem;
+  color: #6b7288;
+}
+
+.password-rules li.ok {
+  color: #047857;
+  font-weight: 600;
+}
+
+.field-error {
+  margin: 0;
+  color: #b91c1c;
+  font-size: 0.82rem;
+}
+
+.alert {
+  margin: 0;
+  border-radius: 0.72rem;
+  padding: 0.72rem 0.82rem;
+  font-size: 0.9rem;
+}
+
+.alert.error {
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  color: #991b1b;
+}
+
+.alert.success {
+  background: #ecfdf5;
+  border: 1px solid #a7f3d0;
+  color: #047857;
+}
+
+.wizard-actions {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.btn-primary,
+.btn-secondary {
+  border: 0;
+  border-radius: 0.85rem;
+  min-height: 2.85rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+}
+
+.btn-primary {
+  background: linear-gradient(90deg, #be123c, #d63f52);
+  color: #fff;
+  box-shadow: 0 14px 22px -14px rgba(190, 18, 60, 0.92);
+}
+
+.btn-primary:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.btn-secondary {
+  border: 1px solid #c9d0de;
+  background: #f6f8fc;
+  color: #1f2438;
+}
+
+footer {
+  margin-top: 1rem;
+  border-top: 1px solid #e5e9f2;
+  padding-top: 0.9rem;
+  text-align: center;
+  font-size: 0.88rem;
+  color: #4a4f63;
+}
+
+footer a {
+  color: #0f3ea8;
+  text-decoration: none;
+  font-weight: 700;
+  margin-left: 0.3rem;
+}
+
+footer a:hover {
+  text-decoration: underline;
+}
+
+@media (max-width: 560px) {
+  .registro-layout {
+    padding: 0.95rem;
+  }
+
+  .registro-card {
+    padding: 1.15rem;
+  }
+
+  .wizard-actions {
+    grid-template-columns: 1fr;
+  }
+}

--- a/transparencia-frontend/src/app/pages/auth/registro.component.html
+++ b/transparencia-frontend/src/app/pages/auth/registro.component.html
@@ -1,0 +1,127 @@
+<section class="registro-layout">
+  <div class="shape shape-top" aria-hidden="true"></div>
+  <div class="shape shape-bottom" aria-hidden="true"></div>
+
+  <article class="registro-card">
+    <header>
+      <p class="eyebrow">SAIP · Registro</p>
+      <h1>Crear cuenta ciudadana</h1>
+      <p>Complete el proceso en dos pasos para habilitar su acceso.</p>
+
+      <div class="wizard-indicator" aria-hidden="true">
+        <span [class.active]="pasoActual() === 1">1. Identidad</span>
+        <span [class.active]="pasoActual() === 2">2. Seguridad</span>
+      </div>
+    </header>
+
+    <form [formGroup]="form" (ngSubmit)="onRegistrar()" novalidate>
+      <ng-container *ngIf="pasoActual() === 1">
+        <div class="form-row">
+          <label for="dni">DNI</label>
+          <input
+            #dniInput
+            id="dni"
+            formControlName="dni"
+            maxlength="8"
+            inputmode="numeric"
+            placeholder="12345678"
+            (input)="onDniInput(dniInput.value)"
+          />
+          <p class="field-error" *ngIf="dniError()">{{ dniError() }}</p>
+        </div>
+
+        <div class="form-row">
+          <label for="nombreCompleto">Nombre completo</label>
+          <input
+            id="nombreCompleto"
+            formControlName="nombreCompleto"
+            autocomplete="name"
+            placeholder="Nombres y apellidos"
+          />
+          <p class="field-error" *ngIf="nombreError()">{{ nombreError() }}</p>
+        </div>
+
+        <button type="button" class="btn-primary" (click)="irPasoDos()">
+          Continuar
+        </button>
+      </ng-container>
+
+      <ng-container *ngIf="pasoActual() === 2">
+        <div class="form-row">
+          <label for="email">Correo electrónico</label>
+          <input
+            id="email"
+            type="email"
+            formControlName="email"
+            autocomplete="email"
+            placeholder="correo@ejemplo.com"
+          />
+          <p class="field-error" *ngIf="emailError()">{{ emailError() }}</p>
+        </div>
+
+        <div class="form-row">
+          <label for="password">Contraseña</label>
+          <input
+            id="password"
+            type="password"
+            formControlName="password"
+            autocomplete="new-password"
+            placeholder="Mínimo 6 caracteres"
+          />
+          <p class="field-error" *ngIf="passwordError()">{{ passwordError() }}</p>
+
+          <ul class="password-rules">
+            <li [class.ok]="cumpleLongitud()">Mínimo 6 caracteres</li>
+            <li [class.ok]="cumpleMayuscula()">Al menos 1 mayúscula</li>
+            <li [class.ok]="cumpleNumero()">Al menos 1 número</li>
+          </ul>
+        </div>
+
+        <div class="form-row">
+          <label for="confirmarPassword">Confirmar contraseña</label>
+          <input
+            id="confirmarPassword"
+            type="password"
+            formControlName="confirmarPassword"
+            autocomplete="new-password"
+            placeholder="Repita la contraseña"
+          />
+          <p class="field-error" *ngIf="confirmarPasswordError()">{{ confirmarPasswordError() }}</p>
+        </div>
+
+        <div class="form-row">
+          <label for="telefono">Teléfono (opcional)</label>
+          <input
+            id="telefono"
+            formControlName="telefono"
+            placeholder="987654321"
+          />
+        </div>
+
+        <div class="form-row">
+          <label for="direccion">Dirección (opcional)</label>
+          <input
+            id="direccion"
+            formControlName="direccion"
+            placeholder="Av. Ejemplo 123"
+          />
+        </div>
+
+        <p class="alert error" *ngIf="errorMessage()">{{ errorMessage() }}</p>
+        <p class="alert success" *ngIf="successMessage()">{{ successMessage() }}</p>
+
+        <div class="wizard-actions">
+          <button type="button" class="btn-secondary" (click)="volverPasoUno()">Atrás</button>
+          <button type="submit" class="btn-primary" [disabled]="loading()">
+            {{ loading() ? 'Registrando...' : 'Registrar cuenta' }}
+          </button>
+        </div>
+      </ng-container>
+    </form>
+
+    <footer>
+      <span>¿Ya tiene una cuenta?</span>
+      <a routerLink="/login">Ir a iniciar sesión</a>
+    </footer>
+  </article>
+</section>

--- a/transparencia-frontend/src/app/pages/auth/registro.component.ts
+++ b/transparencia-frontend/src/app/pages/auth/registro.component.ts
@@ -1,0 +1,275 @@
+import { CommonModule } from '@angular/common';
+import { ChangeDetectionStrategy, Component, signal, inject } from '@angular/core';
+import { AbstractControl, FormBuilder, ReactiveFormsModule, ValidationErrors, Validators } from '@angular/forms';
+import { Router, RouterLink } from '@angular/router';
+import { AuthService } from '../../services/auth.service';
+import { RegistroRequest } from '../../models/usuario.model';
+
+function passwordStrengthValidator(control: AbstractControl): ValidationErrors | null {
+  const value = String(control.value ?? '');
+
+  if (!value) {
+    return null;
+  }
+
+  const hasUppercase = /[A-Z]/.test(value);
+  const hasNumber = /\d/.test(value);
+
+  return hasUppercase && hasNumber ? null : { passwordStrength: true };
+}
+
+function passwordMatchValidator(group: AbstractControl): ValidationErrors | null {
+  const password = String(group.get('password')?.value ?? '');
+  const confirmarPassword = String(group.get('confirmarPassword')?.value ?? '');
+
+  if (!password || !confirmarPassword) {
+    return null;
+  }
+
+  return password === confirmarPassword ? null : { passwordMismatch: true };
+}
+
+@Component({
+  selector: 'app-registro',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [CommonModule, ReactiveFormsModule, RouterLink],
+  templateUrl: './registro.component.html',
+  styleUrl: './registro.component.css'
+})
+export class RegistroComponent {
+  private readonly formBuilder = inject(FormBuilder);
+  private readonly authService = inject(AuthService);
+  private readonly router = inject(Router);
+
+  readonly pasoActual = signal<1 | 2>(1);
+  readonly loading = signal(false);
+  readonly errorMessage = signal('');
+  readonly successMessage = signal('');
+
+  readonly form = this.formBuilder.nonNullable.group(
+    {
+      dni: ['', [Validators.required, Validators.pattern(/^\d{8}$/)]],
+      nombreCompleto: ['', [Validators.required, Validators.minLength(3)]],
+      email: ['', [Validators.required, Validators.email]],
+      password: ['', [Validators.required, Validators.minLength(6), passwordStrengthValidator]],
+      confirmarPassword: ['', [Validators.required]],
+      telefono: [''],
+      direccion: ['']
+    },
+    { validators: [passwordMatchValidator] }
+  );
+
+  get dniControl() {
+    return this.form.controls.dni;
+  }
+
+  get nombreCompletoControl() {
+    return this.form.controls.nombreCompleto;
+  }
+
+  get emailControl() {
+    return this.form.controls.email;
+  }
+
+  get passwordControl() {
+    return this.form.controls.password;
+  }
+
+  get confirmarPasswordControl() {
+    return this.form.controls.confirmarPassword;
+  }
+
+  onDniInput(value: string): void {
+    const cleaned = value.replace(/\D/g, '').slice(0, 8);
+    this.dniControl.setValue(cleaned, { emitEvent: false });
+  }
+
+  irPasoDos(): void {
+    this.errorMessage.set('');
+
+    if (this.dniControl.invalid || this.nombreCompletoControl.invalid) {
+      this.dniControl.markAsTouched();
+      this.nombreCompletoControl.markAsTouched();
+      return;
+    }
+
+    this.pasoActual.set(2);
+  }
+
+  volverPasoUno(): void {
+    this.errorMessage.set('');
+    this.pasoActual.set(1);
+  }
+
+  onRegistrar(): void {
+    this.errorMessage.set('');
+    this.successMessage.set('');
+
+    if (this.pasoActual() === 1) {
+      this.irPasoDos();
+      return;
+    }
+
+    if (this.form.invalid) {
+      this.emailControl.markAsTouched();
+      this.passwordControl.markAsTouched();
+      this.confirmarPasswordControl.markAsTouched();
+      return;
+    }
+
+    const payload = this.buildPayload();
+
+    this.loading.set(true);
+
+    this.authService.registro(payload).subscribe({
+      next: (response) => {
+        this.loading.set(false);
+
+        if (!response.success) {
+          this.errorMessage.set(response.mensaje ?? 'No se pudo completar el registro.');
+          return;
+        }
+
+        this.successMessage.set('Registro exitoso. Redirigiendo al acceso ciudadano...');
+        this.form.reset({
+          dni: '',
+          nombreCompleto: '',
+          email: '',
+          password: '',
+          confirmarPassword: '',
+          telefono: '',
+          direccion: ''
+        });
+        this.pasoActual.set(1);
+
+        setTimeout(() => {
+          void this.router.navigate(['/login']);
+        }, 1200);
+      },
+      error: (error: unknown) => {
+        this.loading.set(false);
+        this.errorMessage.set(this.extractErrorMessage(error));
+      }
+    });
+  }
+
+  dniError(): string {
+    if (!this.dniControl.touched) {
+      return '';
+    }
+
+    if (this.dniControl.hasError('required')) {
+      return 'El DNI es obligatorio.';
+    }
+
+    if (this.dniControl.hasError('pattern')) {
+      return 'El DNI debe tener exactamente 8 dígitos.';
+    }
+
+    return '';
+  }
+
+  nombreError(): string {
+    if (!this.nombreCompletoControl.touched) {
+      return '';
+    }
+
+    if (this.nombreCompletoControl.hasError('required')) {
+      return 'El nombre completo es obligatorio.';
+    }
+
+    if (this.nombreCompletoControl.hasError('minlength')) {
+      return 'Ingrese nombres y apellidos válidos.';
+    }
+
+    return '';
+  }
+
+  emailError(): string {
+    if (!this.emailControl.touched) {
+      return '';
+    }
+
+    if (this.emailControl.hasError('required')) {
+      return 'El correo es obligatorio.';
+    }
+
+    if (this.emailControl.hasError('email')) {
+      return 'Ingrese un correo válido.';
+    }
+
+    return '';
+  }
+
+  passwordError(): string {
+    if (!this.passwordControl.touched) {
+      return '';
+    }
+
+    if (this.passwordControl.hasError('required')) {
+      return 'La contraseña es obligatoria.';
+    }
+
+    if (this.passwordControl.hasError('minlength')) {
+      return 'La contraseña debe tener al menos 6 caracteres.';
+    }
+
+    if (this.passwordControl.hasError('passwordStrength')) {
+      return 'La contraseña debe incluir 1 mayúscula y 1 número.';
+    }
+
+    return '';
+  }
+
+  confirmarPasswordError(): string {
+    if (!this.confirmarPasswordControl.touched) {
+      return '';
+    }
+
+    if (this.confirmarPasswordControl.hasError('required')) {
+      return 'Debe confirmar la contraseña.';
+    }
+
+    if (this.form.hasError('passwordMismatch')) {
+      return 'Las contraseñas no coinciden.';
+    }
+
+    return '';
+  }
+
+  cumpleLongitud(): boolean {
+    return this.passwordControl.value.length >= 6;
+  }
+
+  cumpleMayuscula(): boolean {
+    return /[A-Z]/.test(this.passwordControl.value);
+  }
+
+  cumpleNumero(): boolean {
+    return /\d/.test(this.passwordControl.value);
+  }
+
+  private buildPayload(): RegistroRequest {
+    const data = this.form.getRawValue();
+
+    return {
+      dni: data.dni,
+      nombreCompleto: data.nombreCompleto.trim(),
+      email: data.email.trim(),
+      password: data.password,
+      telefono: data.telefono.trim() || undefined,
+      direccion: data.direccion.trim() || undefined
+    };
+  }
+
+  private extractErrorMessage(error: unknown): string {
+    if (typeof error === 'object' && error !== null && 'error' in error) {
+      const payload = (error as { error?: { mensaje?: string } }).error;
+      if (payload?.mensaje) {
+        return payload.mensaje;
+      }
+    }
+
+    return 'No se pudo registrar al ciudadano. Verifique los datos e intente nuevamente.';
+  }
+}

--- a/transparencia-frontend/src/app/pages/auth/registro.component.ts
+++ b/transparencia-frontend/src/app/pages/auth/registro.component.ts
@@ -143,7 +143,7 @@ export class RegistroComponent {
         this.pasoActual.set(1);
 
         setTimeout(() => {
-          void this.router.navigate(['/login']);
+          void this.router.navigate(['/login'], { queryParams: { registered: '1' } });
         }, 1200);
       },
       error: (error: unknown) => {

--- a/transparencia-frontend/src/app/services/auth.service.ts
+++ b/transparencia-frontend/src/app/services/auth.service.ts
@@ -1,0 +1,54 @@
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable, PLATFORM_ID } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+import { Observable } from 'rxjs';
+import { LoginRequest, LoginResponse, RegistroRequest, RegistroResponse } from '../models/usuario.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AuthService {
+  private readonly http = inject(HttpClient);
+  private readonly platformId = inject(PLATFORM_ID);
+  private readonly isBrowser = isPlatformBrowser(this.platformId);
+  private readonly apiUrl = '/api/auth';
+
+  login(credentials: LoginRequest): Observable<LoginResponse> {
+    return this.http.post<LoginResponse>(`${this.apiUrl}/login`, credentials);
+  }
+
+  registro(data: RegistroRequest): Observable<RegistroResponse> {
+    return this.http.post<RegistroResponse>(`${this.apiUrl}/registro`, data);
+  }
+
+  guardarSesion(data: LoginResponse): void {
+    if (this.isBrowser && typeof localStorage !== 'undefined') {
+      localStorage.setItem('usuario', JSON.stringify(data));
+    }
+  }
+
+  obtenerSesion(): LoginResponse | null {
+    if (!this.isBrowser || typeof localStorage === 'undefined') {
+      return null;
+    }
+
+    const data = localStorage.getItem('usuario');
+    return data ? JSON.parse(data) as LoginResponse : null;
+  }
+
+  cerrarSesion(): void {
+    if (this.isBrowser && typeof localStorage !== 'undefined') {
+      localStorage.removeItem('usuario');
+    }
+  }
+
+  estaLogueado(): boolean {
+    const sesion = this.obtenerSesion();
+    return Boolean(sesion?.token);
+  }
+
+  getTipoUsuario(): string | null {
+    const sesion = this.obtenerSesion();
+    return sesion?.tipoUsuario ? String(sesion.tipoUsuario) : null;
+  }
+}


### PR DESCRIPTION
## Contexto
Implementa FE-01 de HU-01 para maquetar Login y Registro con flujo de autenticación inicial y experiencia de registro en 2 pasos.

## Cambios incluidos
* Se agregan componentes standalone de auth: Login y Registro en `pages/auth/`.
* Se registran rutas de acceso ciudadano e interno (`/login`, `/acceso-funcionario`, `/acceso-ttaip`, `/acceso-admin`, `/registro`) integradas con las rutas existentes.
* Se agrega `AuthService` base y modelos de usuario/login/registro para el flujo FE-01.
* Se mejora el feedback post-registro: redirección a login con mensaje de éxito visible.

## Trazabilidad de sub-issues
* Closes HU-01 · FE-01 · Maquetar Login y Registro #15
* Commit: a468a25032ee4265f13c8f64b4f5d71eafec21ea
* Commit: d186a1771fc706f2721a0034f5e65fcc9b2b56df

## Validación
* Frontend build: `cd transparencia-frontend && npm run build` → OK
* Frontend test: `cd transparencia-frontend && npm test -- --watch=false` → OK

## Riesgos y mitigaciones
* Riesgo: solape de rutas al integrar auth con rutas ya existentes en develop.
* Mitigación: se preservan rutas actuales y se agregan rutas auth sin alterar el redirect final existente.

## Checklist de revisión
- [ ] Verificar maquetación y validaciones de Login (DNI/email según modo de acceso)
- [ ] Verificar wizard de Registro (2 pasos + reglas de contraseña)
- [ ] Verificar feedback post-registro en login
- [ ] Tests y build en verde