### PR TITLE
🔀 feat(HU-03): FE-01 · implementar dashboard de funcionario

### DIFF
--- a/transparencia-frontend/src/app/app.routes.ts
+++ b/transparencia-frontend/src/app/app.routes.ts
@@ -18,6 +18,10 @@ export const routes: Routes = [
     loadComponent: () => import('./pages/ciudadano/subsanacion.component').then(m => m.SubsanacionComponent)
   },
   {
+    path: 'funcionario',
+    loadComponent: () => import('./pages/funcionario/funcionario-dashboard.component').then(m => m.FuncionarioDashboardComponent)
+  },
+  {
     path: 'ttaip',
     loadComponent: () => import('./pages/ttaip/ttaip-dashboard.component').then(m => m.TtaipDashboardComponent)
   },

--- a/transparencia-frontend/src/app/pages/funcionario/funcionario-dashboard.component.css
+++ b/transparencia-frontend/src/app/pages/funcionario/funcionario-dashboard.component.css
@@ -1,0 +1,28 @@
+:host {
+  display: block;
+}
+
+.summary-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  border: 1px solid var(--ceniza-claro);
+  border-radius: 0.85rem;
+  background: var(--blanco);
+  padding: 1rem;
+  box-shadow: var(--shadow-sm);
+}
+
+.summary-label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--niebla);
+}
+
+.summary-value {
+  font-size: 1.6rem;
+  font-weight: 800;
+  line-height: 1;
+}

--- a/transparencia-frontend/src/app/pages/funcionario/funcionario-dashboard.component.html
+++ b/transparencia-frontend/src/app/pages/funcionario/funcionario-dashboard.component.html
@@ -1,0 +1,111 @@
+<div class="min-h-screen bg-(--nieve-calida)">
+  <section class="bg-gradient-peru-hero px-4 pb-10 pt-24">
+    <div class="mx-auto max-w-7xl">
+      <p class="text-sm font-semibold uppercase tracking-[0.08em] text-(--niebla)">HU-03 · FE-01</p>
+      <h1 class="mt-2 text-3xl font-extrabold text-(--carbon)">Dashboard de Funcionario</h1>
+      <p class="mt-1 text-sm text-(--humo)">{{ entidadNombre() }}</p>
+    </div>
+  </section>
+
+  <section class="mx-auto -mt-5 max-w-7xl px-4 pb-10">
+    <div class="grid grid-cols-2 gap-3 md:grid-cols-4">
+      <article class="summary-card">
+        <span class="summary-label">Pendientes</span>
+        <span class="summary-value text-(--estado-azul)">{{ pendientes() }}</span>
+      </article>
+      <article class="summary-card">
+        <span class="summary-label">Urgentes</span>
+        <span class="summary-value text-(--estado-rojo)">{{ urgentes() }}</span>
+      </article>
+      <article class="summary-card">
+        <span class="summary-label">Silencio</span>
+        <span class="summary-value text-(--carbon)">{{ vencidas() }}</span>
+      </article>
+      <article class="summary-card">
+        <span class="summary-label">Respondidas</span>
+        <span class="summary-value text-(--estado-verde)">{{ respondidas() }}</span>
+      </article>
+    </div>
+
+    @if (error()) {
+      <div class="alert-error mt-5">
+        <p>{{ error() }}</p>
+      </div>
+    }
+
+    <div class="card mt-5 overflow-hidden">
+      <div class="border-b border-(--ceniza-claro) px-5 py-4">
+        <h2 class="text-lg font-semibold text-(--carbon)">Solicitudes de la entidad</h2>
+      </div>
+
+      @if (loading()) {
+        <div class="py-16 text-center">
+          <div class="mx-auto h-10 w-10 animate-spin rounded-full border-4 border-(--ceniza) border-t-(--peru-rojo)"></div>
+          <p class="mt-4 text-sm text-(--niebla)">Cargando solicitudes...</p>
+        </div>
+      } @else if (solicitudes().length === 0) {
+        <div class="py-16 text-center">
+          <p class="text-sm text-(--niebla)">No hay solicitudes asignadas para esta entidad.</p>
+        </div>
+      } @else {
+        <div class="overflow-x-auto">
+          <table class="min-w-full border-collapse">
+            <thead class="bg-(--nieve) text-left">
+              <tr>
+                <th class="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-(--humo)">Expediente</th>
+                <th class="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-(--humo)">Asunto</th>
+                <th class="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-(--humo)">Fecha limite</th>
+                <th class="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-(--humo)">Dias restantes</th>
+                <th class="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-(--humo)">Semaforo</th>
+                <th class="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-(--humo)">Estado</th>
+                <th class="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-(--humo) text-right">Accion</th>
+              </tr>
+            </thead>
+            <tbody>
+              @for (solicitud of solicitudes(); track solicitud.idSolicitud) {
+                <tr class="border-t border-(--ceniza-claro)">
+                  <td class="px-4 py-3">
+                    <span class="font-expediente text-sm text-(--carbon)">{{ solicitud.expediente }}</span>
+                  </td>
+                  <td class="max-w-90 px-4 py-3">
+                    <p class="truncate text-sm text-(--humo)" [title]="solicitud.asunto">{{ solicitud.asunto }}</p>
+                  </td>
+                  <td class="px-4 py-3 text-sm text-(--humo)">
+                    @if (solicitud.fechaLimite) {
+                      {{ solicitud.fechaLimite | date: 'dd/MM/yyyy' }}
+                    } @else {
+                      -
+                    }
+                  </td>
+                  <td class="px-4 py-3 text-sm font-semibold text-(--carbon)">
+                    @if (obtenerDiasRestantes(solicitud) !== null) {
+                      {{ obtenerDiasRestantes(solicitud) }}
+                    } @else {
+                      -
+                    }
+                  </td>
+                  <td class="px-4 py-3">
+                    <span class="inline-flex rounded-full px-2.5 py-1 text-xs font-semibold" [class]="obtenerSemaforoClase(solicitud)">
+                      {{ obtenerSemaforoEtiqueta(solicitud) }}
+                    </span>
+                  </td>
+                  <td class="px-4 py-3 text-xs font-semibold text-(--humo)">{{ solicitud.estado }}</td>
+                  <td class="px-4 py-3 text-right">
+                    <button
+                      type="button"
+                      class="btn-primary h-9 px-4 text-xs"
+                      [disabled]="!canResponder(solicitud)"
+                      [title]="canResponder(solicitud) ? 'Responder solicitud' : 'Deshabilitado por silencio administrativo o respuesta previa'"
+                    >
+                      Responder
+                    </button>
+                  </td>
+                </tr>
+              }
+            </tbody>
+          </table>
+        </div>
+      }
+    </div>
+  </section>
+</div>

--- a/transparencia-frontend/src/app/pages/funcionario/funcionario-dashboard.component.ts
+++ b/transparencia-frontend/src/app/pages/funcionario/funcionario-dashboard.component.ts
@@ -1,0 +1,161 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  PLATFORM_ID,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { DatePipe, isPlatformBrowser } from '@angular/common';
+import { Solicitud } from '../../models/solicitud.model';
+import { SolicitudService } from '../../services/solicitud.service';
+
+interface SesionFuncionario {
+  entidadId?: number;
+  entidadNombre?: string;
+}
+
+@Component({
+  selector: 'app-funcionario-dashboard',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [DatePipe],
+  templateUrl: './funcionario-dashboard.component.html',
+  styleUrl: './funcionario-dashboard.component.css',
+})
+export class FuncionarioDashboardComponent {
+  private readonly solicitudService = inject(SolicitudService);
+  private readonly platformId = inject(PLATFORM_ID);
+
+  readonly loading = signal(true);
+  readonly error = signal<string | null>(null);
+  readonly entidadId = signal<number | null>(null);
+  readonly entidadNombre = signal('Entidad publica');
+  readonly solicitudes = signal<Solicitud[]>([]);
+
+  readonly pendientes = computed(() => this.solicitudes().filter((s) => this.canResponder(s)).length);
+
+  readonly vencidas = computed(() => this.solicitudes().filter((s) => this.esSilencioAdministrativo(s)).length);
+
+  readonly respondidas = computed(() => this.solicitudes().filter((s) => this.tieneRespuesta(s)).length);
+
+  readonly urgentes = computed(() =>
+    this.solicitudes().filter((s) => {
+      const dias = this.obtenerDiasRestantes(s);
+      return dias !== null && dias >= 0 && dias <= 1 && this.canResponder(s);
+    }).length,
+  );
+
+  constructor() {
+    this.inicializarDesdeSesion();
+  }
+
+  cargarSolicitudes(): void {
+    const idEntidad = this.entidadId();
+    if (!idEntidad) {
+      this.loading.set(false);
+      this.error.set('No se encontro entidad asociada al funcionario en sesion.');
+      return;
+    }
+
+    this.loading.set(true);
+    this.error.set(null);
+
+    this.solicitudService.findByEntidadId(idEntidad).subscribe({
+      next: (data) => {
+        this.solicitudes.set(data);
+        this.loading.set(false);
+      },
+      error: () => {
+        this.loading.set(false);
+        this.error.set('No se pudieron cargar las solicitudes de la entidad.');
+      },
+    });
+  }
+
+  canResponder(solicitud: Solicitud): boolean {
+    return !this.esSilencioAdministrativo(solicitud) && !this.tieneRespuesta(solicitud);
+  }
+
+  obtenerSemaforoEtiqueta(solicitud: Solicitud): string {
+    const dias = this.obtenerDiasRestantes(solicitud);
+    if (this.esSilencioAdministrativo(solicitud)) {
+      return 'NEGRO';
+    }
+    if (dias === null) {
+      return 'N/A';
+    }
+    if (dias >= 5) {
+      return 'VERDE';
+    }
+    if (dias >= 2) {
+      return 'AMBAR';
+    }
+    if (dias >= 0) {
+      return 'ROJO';
+    }
+    return 'NEGRO';
+  }
+
+  obtenerSemaforoClase(solicitud: Solicitud): string {
+    const etiqueta = this.obtenerSemaforoEtiqueta(solicitud);
+    if (etiqueta === 'VERDE') {
+      return 'bg-emerald-100 text-emerald-700 border border-emerald-200';
+    }
+    if (etiqueta === 'AMBAR') {
+      return 'bg-amber-100 text-amber-700 border border-amber-200';
+    }
+    if (etiqueta === 'ROJO') {
+      return 'bg-red-100 text-red-700 border border-red-200';
+    }
+    if (etiqueta === 'NEGRO') {
+      return 'bg-neutral-800 text-white border border-neutral-700';
+    }
+    return 'bg-neutral-100 text-neutral-700 border border-neutral-200';
+  }
+
+  obtenerDiasRestantes(solicitud: Solicitud): number | null {
+    return typeof solicitud.diasRestantes === 'number' ? solicitud.diasRestantes : null;
+  }
+
+  private inicializarDesdeSesion(): void {
+    if (!isPlatformBrowser(this.platformId)) {
+      this.loading.set(false);
+      return;
+    }
+
+    const rawSesion = localStorage.getItem('usuario');
+    if (!rawSesion) {
+      this.loading.set(false);
+      this.error.set('No hay sesion activa de funcionario.');
+      return;
+    }
+
+    try {
+      const sesion = JSON.parse(rawSesion) as SesionFuncionario;
+      if (typeof sesion.entidadId !== 'number' || sesion.entidadId <= 0) {
+        this.loading.set(false);
+        this.error.set('La sesion no contiene una entidad valida para el funcionario.');
+        return;
+      }
+
+      this.entidadId.set(sesion.entidadId);
+      this.entidadNombre.set(sesion.entidadNombre ?? 'Entidad publica');
+      this.cargarSolicitudes();
+    } catch {
+      this.loading.set(false);
+      this.error.set('No se pudo leer la sesion de usuario.');
+    }
+  }
+
+  private tieneRespuesta(solicitud: Solicitud): boolean {
+    return solicitud.estado === 'RESPONDIDA' || solicitud.estado === 'DENEGADA' || solicitud.estado === 'CONCLUIDA';
+  }
+
+  private esSilencioAdministrativo(solicitud: Solicitud): boolean {
+    const dias = this.obtenerDiasRestantes(solicitud);
+    const porEstado = solicitud.estado === 'VENCIDA';
+    const porDias = dias !== null && dias < 0;
+    const porSemaforo = solicitud.semaforo === 'NEGRO';
+    return porEstado || porDias || porSemaforo;
+  }
+}


### PR DESCRIPTION
## Contexto
Se corrigió la rama `HU03-emitir-respuesta-saip` para que el PR incluya únicamente el alcance de **HU-03 · FE-01** sobre `develop` actualizado, sin commits ajenos.

## Cambios incluidos
- Implementación de `FuncionarioDashboardComponent` con carga de solicitudes por entidad.
- Semáforo visual por días restantes (verde, ámbar, rojo, negro) según backlog.
- Regla `canResponder` para bloquear respuesta manual cuando aplica silencio administrativo o ya existe respuesta.
- Integración de ruta lazy `/funcionario` en el enrutador principal.

## Trazabilidad de sub-issues
- Refs #32
  - `1540095` — dashboard funcionario base
- Closes #32
  - `3cb1c29` — integración de ruta funcionario

## Validación
- `npm test -- --watch=false` ✅
- `npm run build` ✅

## Riesgos y mitigaciones
- Riesgo: cambios futuros en modelo de sesión (`entidadId`) pueden afectar la carga inicial del dashboard.
- Mitigación: mantener contrato de sesión y cubrir con pruebas adicionales en FE-04.

## Checklist de revisión
- [x] PR limitado a FE-01 HU-03
- [x] Diff sin commits de otras HUs
- [x] Frontend tests y build en verde