### PR TITLE
🔀 feat(HU-03): FE-02 · implementar detalle y formulario de respuesta

### DIFF
--- a/transparencia-frontend/src/app/app.routes.ts
+++ b/transparencia-frontend/src/app/app.routes.ts
@@ -26,6 +26,10 @@ export const routes: Routes = [
     loadComponent: () => import('./pages/funcionario/funcionario-solicitud-detalle.component').then(m => m.FuncionarioSolicitudDetalleComponent)
   },
   {
+    path: 'funcionario/responder/:expediente',
+    loadComponent: () => import('./pages/funcionario/funcionario-responder.component').then(m => m.FuncionarioResponderComponent)
+  },
+  {
     path: 'ttaip',
     loadComponent: () => import('./pages/ttaip/ttaip-dashboard.component').then(m => m.TtaipDashboardComponent)
   },

--- a/transparencia-frontend/src/app/app.routes.ts
+++ b/transparencia-frontend/src/app/app.routes.ts
@@ -22,6 +22,10 @@ export const routes: Routes = [
     loadComponent: () => import('./pages/funcionario/funcionario-dashboard.component').then(m => m.FuncionarioDashboardComponent)
   },
   {
+    path: 'funcionario/solicitud/:expediente',
+    loadComponent: () => import('./pages/funcionario/funcionario-solicitud-detalle.component').then(m => m.FuncionarioSolicitudDetalleComponent)
+  },
+  {
     path: 'ttaip',
     loadComponent: () => import('./pages/ttaip/ttaip-dashboard.component').then(m => m.TtaipDashboardComponent)
   },

--- a/transparencia-frontend/src/app/pages/funcionario/funcionario-dashboard.component.html
+++ b/transparencia-frontend/src/app/pages/funcionario/funcionario-dashboard.component.html
@@ -100,14 +100,25 @@
                         Detalle
                       </a>
 
-                      <button
-                        type="button"
-                        class="btn-primary h-9 px-4 text-xs"
-                        [disabled]="!canResponder(solicitud)"
-                        [title]="canResponder(solicitud) ? 'Responder solicitud' : 'Deshabilitado por silencio administrativo o respuesta previa'"
-                      >
-                        Responder
-                      </button>
+                      @if (canResponder(solicitud)) {
+                        <a
+                          class="btn-primary h-9 px-4 text-xs"
+                          [routerLink]="['/funcionario/responder', solicitud.expediente]"
+                          style="text-decoration: none;"
+                          title="Responder solicitud"
+                        >
+                          Responder
+                        </a>
+                      } @else {
+                        <button
+                          type="button"
+                          class="btn-primary h-9 px-4 text-xs"
+                          [disabled]="true"
+                          title="Deshabilitado por silencio administrativo o respuesta previa"
+                        >
+                          Responder
+                        </button>
+                      }
                     </div>
                   </td>
                 </tr>

--- a/transparencia-frontend/src/app/pages/funcionario/funcionario-dashboard.component.html
+++ b/transparencia-frontend/src/app/pages/funcionario/funcionario-dashboard.component.html
@@ -91,14 +91,24 @@
                   </td>
                   <td class="px-4 py-3 text-xs font-semibold text-(--humo)">{{ solicitud.estado }}</td>
                   <td class="px-4 py-3 text-right">
-                    <button
-                      type="button"
-                      class="btn-primary h-9 px-4 text-xs"
-                      [disabled]="!canResponder(solicitud)"
-                      [title]="canResponder(solicitud) ? 'Responder solicitud' : 'Deshabilitado por silencio administrativo o respuesta previa'"
-                    >
-                      Responder
-                    </button>
+                    <div class="flex items-center justify-end gap-2">
+                      <a
+                        class="btn-outline h-9 px-3 text-xs"
+                        [routerLink]="['/funcionario/solicitud', solicitud.expediente]"
+                        style="text-decoration: none;"
+                      >
+                        Detalle
+                      </a>
+
+                      <button
+                        type="button"
+                        class="btn-primary h-9 px-4 text-xs"
+                        [disabled]="!canResponder(solicitud)"
+                        [title]="canResponder(solicitud) ? 'Responder solicitud' : 'Deshabilitado por silencio administrativo o respuesta previa'"
+                      >
+                        Responder
+                      </button>
+                    </div>
                   </td>
                 </tr>
               }

--- a/transparencia-frontend/src/app/pages/funcionario/funcionario-dashboard.component.ts
+++ b/transparencia-frontend/src/app/pages/funcionario/funcionario-dashboard.component.ts
@@ -7,6 +7,7 @@ import {
   signal,
 } from '@angular/core';
 import { DatePipe, isPlatformBrowser } from '@angular/common';
+import { RouterLink } from '@angular/router';
 import { Solicitud } from '../../models/solicitud.model';
 import { SolicitudService } from '../../services/solicitud.service';
 
@@ -18,7 +19,7 @@ interface SesionFuncionario {
 @Component({
   selector: 'app-funcionario-dashboard',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [DatePipe],
+  imports: [DatePipe, RouterLink],
   templateUrl: './funcionario-dashboard.component.html',
   styleUrl: './funcionario-dashboard.component.css',
 })

--- a/transparencia-frontend/src/app/pages/funcionario/funcionario-responder.component.css
+++ b/transparencia-frontend/src/app/pages/funcionario/funcionario-responder.component.css
@@ -1,0 +1,89 @@
+:host {
+  display: block;
+}
+
+.summary-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  border: 1px solid var(--ceniza-claro);
+  border-radius: 0.85rem;
+  background: var(--blanco);
+  padding: 1rem;
+  box-shadow: var(--shadow-sm);
+}
+
+.summary-label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--niebla);
+}
+
+.summary-value {
+  font-size: 1.1rem;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.decision-card {
+  align-items: flex-start;
+  background: var(--blanco);
+  border: 2px solid var(--ceniza-claro);
+  border-radius: 0.9rem;
+  cursor: pointer;
+  display: flex;
+  gap: 0.75rem;
+  padding: 0.85rem;
+  transition: border-color 180ms ease, background-color 180ms ease;
+}
+
+.decision-card input[type='radio'] {
+  accent-color: var(--peru-rojo);
+  margin-top: 0.1rem;
+}
+
+.decision-card.active-accept {
+  border-color: var(--estado-verde);
+  background: var(--estado-verde-suave);
+}
+
+.decision-card.active-deny {
+  border-color: var(--estado-rojo);
+  background: var(--estado-rojo-suave);
+}
+
+.decision-title {
+  color: var(--carbon);
+  font-size: 0.92rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.decision-desc {
+  color: var(--niebla);
+  font-size: 0.77rem;
+  margin: 0.2rem 0 0;
+}
+
+.file-input {
+  border: 1px solid var(--ceniza-claro);
+  border-radius: 0.75rem;
+  color: var(--humo);
+  display: block;
+  font-size: 0.85rem;
+  padding: 0.5rem;
+  width: 100%;
+}
+
+.file-preview-item {
+  align-items: center;
+  background: var(--nieve);
+  border: 1px solid var(--ceniza-claro);
+  border-radius: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.6rem 0.75rem;
+}

--- a/transparencia-frontend/src/app/pages/funcionario/funcionario-responder.component.html
+++ b/transparencia-frontend/src/app/pages/funcionario/funcionario-responder.component.html
@@ -1,0 +1,235 @@
+<div class="min-h-screen bg-(--nieve-calida)">
+  @if (loadingSolicitud()) {
+    <section class="bg-gradient-peru-hero px-4 pb-10 pt-24">
+      <div class="mx-auto max-w-7xl">
+        <h1 class="text-2xl font-semibold text-(--carbon)">Cargando formulario de respuesta...</h1>
+      </div>
+    </section>
+    <section class="mx-auto max-w-7xl px-4 py-14 text-center">
+      <div class="mx-auto h-10 w-10 animate-spin rounded-full border-4 border-(--ceniza) border-t-(--peru-rojo)"></div>
+    </section>
+  } @else if (error() && !solicitud()) {
+    <section class="bg-gradient-peru-hero px-4 pb-10 pt-24">
+      <div class="mx-auto max-w-7xl">
+        <a
+          routerLink="/funcionario"
+          class="inline-flex items-center gap-2 text-sm text-(--humo) transition hover:text-(--carbon)"
+          style="text-decoration: none;"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m12 19-7-7 7-7"/><path d="M19 12H5"/></svg>
+          Volver al Dashboard
+        </a>
+      </div>
+    </section>
+    <section class="mx-auto max-w-7xl px-4 pb-10">
+      <div class="alert-error">
+        <p>{{ error() }}</p>
+      </div>
+    </section>
+  } @else if (solicitud(); as solicitudData) {
+    <section class="bg-gradient-peru-hero px-4 pb-10 pt-24">
+      <div class="mx-auto max-w-7xl">
+        <a
+          [routerLink]="['/funcionario/solicitud', solicitudData.expediente]"
+          class="inline-flex items-center gap-2 text-sm text-(--humo) transition hover:text-(--carbon)"
+          style="text-decoration: none;"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m12 19-7-7 7-7"/><path d="M19 12H5"/></svg>
+          Volver al detalle
+        </a>
+
+        <div class="mt-4 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <p class="text-sm font-semibold uppercase tracking-[0.08em] text-(--niebla)">HU-03 · FE-02</p>
+            <h1 class="mt-1 text-3xl font-extrabold text-(--carbon)">Responder Solicitud</h1>
+            <p class="mt-1 font-expediente text-sm text-(--humo)">{{ solicitudData.expediente }}</p>
+          </div>
+
+          <span class="inline-flex w-fit rounded-full px-3 py-1 text-xs font-semibold" [class]="obtenerEstadoClase(solicitudData.estado)">
+            {{ solicitudData.estado }}
+          </span>
+        </div>
+      </div>
+    </section>
+
+    <section class="mx-auto -mt-5 max-w-7xl px-4 pb-10">
+      <div class="grid grid-cols-2 gap-3 md:grid-cols-4">
+        <article class="summary-card">
+          <span class="summary-label">Fecha solicitud</span>
+          <span class="summary-value text-(--estado-azul)">
+            @if (solicitudData.fechaPresentacion) {
+              {{ solicitudData.fechaPresentacion | date: 'dd/MM/yyyy' }}
+            } @else {
+              -
+            }
+          </span>
+        </article>
+
+        <article class="summary-card">
+          <span class="summary-label">Fecha limite</span>
+          <span class="summary-value text-(--estado-ambar)">
+            @if (solicitudData.fechaLimite) {
+              {{ solicitudData.fechaLimite | date: 'dd/MM/yyyy' }}
+            } @else {
+              -
+            }
+          </span>
+        </article>
+
+        <article class="summary-card">
+          <span class="summary-label">Dias restantes</span>
+          <span class="summary-value" [class]="obtenerDiasRestantes(solicitudData) !== null && obtenerDiasRestantes(solicitudData)! < 0 ? 'text-(--estado-rojo)' : 'text-(--estado-verde)'">
+            {{ obtenerTextoDiasRestantes(solicitudData) }}
+          </span>
+        </article>
+
+        <article class="summary-card">
+          <span class="summary-label">Solicitante</span>
+          <span class="summary-value text-(--accent-violet)">
+            {{ solicitudData.ciudadanoNombre || 'Ciudadano' }}
+          </span>
+        </article>
+      </div>
+
+      @if (error()) {
+        <div class="alert-error mt-5">
+          <p>{{ error() }}</p>
+        </div>
+      }
+
+      @if (mensaje()) {
+        <div class="alert-success mt-5">
+          <p>{{ mensaje() }}</p>
+        </div>
+      }
+
+      <div class="card mt-5 overflow-hidden">
+        <div class="border-b border-(--ceniza-claro) px-5 py-4">
+          <h2 class="text-lg font-semibold text-(--carbon)">Formulario de respuesta</h2>
+          <p class="mt-1 text-sm text-(--niebla)">
+            Selector aceptar/denegar con campos condicionales y previsualizacion de archivos.
+          </p>
+        </div>
+
+        <div class="p-5 md:p-6">
+          @if (!puedeRegistrarRespuesta()) {
+            <div class="alert-warning">
+              <p>
+                No se permite registrar respuesta manual porque la solicitud esta vencida por silencio administrativo o ya fue atendida.
+              </p>
+            </div>
+          }
+
+          <form [formGroup]="formulario" class="space-y-5" (ngSubmit)="enviarRespuesta()">
+            <div class="space-y-3">
+              <p class="label mb-0!">Decision sobre la solicitud <span class="text-(--estado-rojo)">*</span></p>
+
+              <label class="decision-card" [class.active-accept]="formulario.controls.decision.value === 'ACEPTAR'">
+                <input type="radio" formControlName="decision" value="ACEPTAR" />
+                <div>
+                  <p class="decision-title">Aceptar</p>
+                  <p class="decision-desc">Se prepara entrega de informacion al ciudadano.</p>
+                </div>
+              </label>
+
+              <label class="decision-card" [class.active-deny]="formulario.controls.decision.value === 'DENEGAR'">
+                <input type="radio" formControlName="decision" value="DENEGAR" />
+                <div>
+                  <p class="decision-title">Denegar</p>
+                  <p class="decision-desc">Se requiere causal y fundamento legal obligatorio.</p>
+                </div>
+              </label>
+            </div>
+
+            <div class="space-y-2">
+              <label class="label" for="contenido">Contenido de respuesta <span class="text-(--estado-rojo)">*</span></label>
+              <textarea
+                id="contenido"
+                class="input"
+                rows="4"
+                formControlName="contenido"
+                placeholder="Describa la informacion que se entrega o la motivacion de la denegatoria..."
+              ></textarea>
+              @if (campoInvalido('contenido')) {
+                <p class="error-text">Ingrese una descripcion valida (minimo 20 caracteres).</p>
+              }
+            </div>
+
+            @if (mostrarCamposDenegacion()) {
+              <div class="space-y-4 rounded-xl border border-(--estado-rojo-borde) bg-(--estado-rojo-suave) p-4">
+                <div class="space-y-2">
+                  <label class="label" for="causal">Causal de denegatoria <span class="text-(--estado-rojo)">*</span></label>
+                  <select id="causal" class="input" formControlName="causalDenegatoria">
+                    <option value="">Seleccione causal</option>
+                    @for (causal of causalesDenegacion; track causal) {
+                      <option [value]="causal">{{ causal }}</option>
+                    }
+                  </select>
+                  @if (campoInvalido('causalDenegatoria')) {
+                    <p class="error-text">Seleccione una causal de denegatoria.</p>
+                  }
+                </div>
+
+                <div class="space-y-2">
+                  <label class="label" for="fundamento">Fundamento legal <span class="text-(--estado-rojo)">*</span></label>
+                  <textarea
+                    id="fundamento"
+                    class="input"
+                    rows="5"
+                    formControlName="fundamentoLegal"
+                    placeholder="Cite la base normativa que justifica la denegatoria..."
+                  ></textarea>
+                  @if (campoInvalido('fundamentoLegal')) {
+                    <p class="error-text">Ingrese fundamento legal (minimo 30 caracteres).</p>
+                  }
+                </div>
+              </div>
+            }
+
+            <div class="space-y-2">
+              <label class="label" for="archivos">Adjuntar archivos <span class="text-(--estado-rojo)">*</span></label>
+              <input
+                id="archivos"
+                type="file"
+                multiple
+                class="file-input"
+                (change)="onSeleccionArchivos($event)"
+              />
+              <p class="helper">Puede adjuntar uno o varios archivos para la respuesta.</p>
+
+              @if (previewArchivos().length > 0) {
+                <div class="space-y-2 pt-2">
+                  @for (archivo of previewArchivos(); track archivo.nombre + archivo.tamano; let i = $index) {
+                    <article class="file-preview-item">
+                      <div>
+                        <p class="text-sm font-semibold text-(--carbon)">{{ archivo.nombre }}</p>
+                        <p class="text-xs text-(--niebla)">{{ archivo.tamano }}</p>
+                      </div>
+                      <button type="button" class="btn-outline h-8 px-3 text-xs" (click)="quitarArchivo(i)">
+                        Quitar
+                      </button>
+                    </article>
+                  }
+                </div>
+              }
+            </div>
+
+            <div class="pt-2">
+              <button
+                type="submit"
+                class="btn-primary h-11 w-full"
+                [disabled]="loading() || !puedeRegistrarRespuesta()"
+              >
+                @if (loading()) {
+                  Enviando...
+                } @else {
+                  Validar respuesta
+                }
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </section>
+  }
+</div>

--- a/transparencia-frontend/src/app/pages/funcionario/funcionario-responder.component.ts
+++ b/transparencia-frontend/src/app/pages/funcionario/funcionario-responder.component.ts
@@ -1,0 +1,242 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { DatePipe } from '@angular/common';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import { Solicitud } from '../../models/solicitud.model';
+import { SolicitudService } from '../../services/solicitud.service';
+
+type DecisionFormulario = 'ACEPTAR' | 'DENEGAR';
+
+interface ArchivoPreview {
+  nombre: string;
+  tamano: string;
+}
+
+@Component({
+  selector: 'app-funcionario-responder',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [ReactiveFormsModule, RouterLink, DatePipe],
+  templateUrl: './funcionario-responder.component.html',
+  styleUrl: './funcionario-responder.component.css',
+})
+export class FuncionarioResponderComponent {
+  private readonly route = inject(ActivatedRoute);
+  private readonly solicitudService = inject(SolicitudService);
+  private readonly fb = inject(FormBuilder);
+
+  readonly loading = signal(false);
+  readonly loadingSolicitud = signal(true);
+  readonly error = signal<string | null>(null);
+  readonly mensaje = signal<string | null>(null);
+  readonly solicitud = signal<Solicitud | null>(null);
+  readonly archivosAdjuntos = signal<File[]>([]);
+
+  readonly causalesDenegacion = [
+    'Informacion confidencial',
+    'Informacion reservada',
+    'Informacion secreta',
+    'Proteccion de datos personales',
+    'Seguridad nacional',
+  ];
+
+  readonly formulario = this.fb.nonNullable.group({
+    decision: this.fb.nonNullable.control<DecisionFormulario>('ACEPTAR'),
+    contenido: this.fb.nonNullable.control('', [Validators.required, Validators.minLength(20)]),
+    causalDenegatoria: this.fb.control(''),
+    fundamentoLegal: this.fb.control(''),
+  });
+
+  readonly mostrarCamposDenegacion = computed(
+    () => this.formulario.controls.decision.value === 'DENEGAR',
+  );
+
+  readonly puedeRegistrarRespuesta = computed(() => {
+    const solicitud = this.solicitud();
+    if (!solicitud) {
+      return false;
+    }
+
+    return !this.esSilencioAdministrativo(solicitud) && !this.tieneRespuesta(solicitud);
+  });
+
+  readonly previewArchivos = computed<ArchivoPreview[]>(() =>
+    this.archivosAdjuntos().map((archivo) => ({
+      nombre: archivo.name,
+      tamano: this.formatearTamano(archivo.size),
+    })),
+  );
+
+  constructor() {
+    this.formulario.controls.decision.valueChanges.subscribe((decision) => {
+      this.actualizarValidacionesSegunDecision(decision);
+    });
+
+    this.actualizarValidacionesSegunDecision(this.formulario.controls.decision.value);
+    this.cargarSolicitudDesdeRuta();
+  }
+
+  onSeleccionArchivos(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    const files = input.files ? Array.from(input.files) : [];
+    this.archivosAdjuntos.set(files);
+  }
+
+  quitarArchivo(index: number): void {
+    const archivos = [...this.archivosAdjuntos()];
+    archivos.splice(index, 1);
+    this.archivosAdjuntos.set(archivos);
+  }
+
+  enviarRespuesta(): void {
+    this.error.set(null);
+    this.mensaje.set(null);
+
+    if (!this.puedeRegistrarRespuesta()) {
+      this.error.set('No se permite registrar respuesta manual para esta solicitud.');
+      return;
+    }
+
+    this.formulario.markAllAsTouched();
+
+    if (this.archivosAdjuntos().length === 0) {
+      this.error.set('Debe adjuntar al menos un archivo para la respuesta.');
+      return;
+    }
+
+    if (this.formulario.invalid) {
+      this.error.set('Complete los campos obligatorios antes de enviar la respuesta.');
+      return;
+    }
+
+    this.loading.set(true);
+
+    setTimeout(() => {
+      this.loading.set(false);
+      this.mensaje.set(
+        this.formulario.controls.decision.value === 'ACEPTAR'
+          ? 'Respuesta de aceptacion validada. Lista para integracion con API en FE-03.'
+          : 'Respuesta de denegacion validada. Lista para integracion con API en FE-03.',
+      );
+    }, 450);
+  }
+
+  obtenerEstadoClase(estado: string): string {
+    if (estado === 'RESPONDIDA' || estado === 'CONCLUIDA') {
+      return 'bg-emerald-100 text-emerald-700 border border-emerald-200';
+    }
+
+    if (estado === 'DENEGADA') {
+      return 'bg-red-100 text-red-700 border border-red-200';
+    }
+
+    if (estado === 'VENCIDA') {
+      return 'bg-neutral-800 text-white border border-neutral-700';
+    }
+
+    if (estado === 'EN_REVISION') {
+      return 'bg-blue-100 text-blue-700 border border-blue-200';
+    }
+
+    return 'bg-amber-100 text-amber-700 border border-amber-200';
+  }
+
+  campoInvalido(nombre: 'contenido' | 'causalDenegatoria' | 'fundamentoLegal'): boolean {
+    const control = this.formulario.controls[nombre];
+    return control.invalid && control.touched;
+  }
+
+  obtenerDiasRestantes(solicitud: Solicitud): number | null {
+    return typeof solicitud.diasRestantes === 'number' ? solicitud.diasRestantes : null;
+  }
+
+  obtenerTextoDiasRestantes(solicitud: Solicitud): string {
+    const dias = this.obtenerDiasRestantes(solicitud);
+    if (dias === null) {
+      return 'No disponible';
+    }
+
+    if (dias < 0) {
+      return `${Math.abs(dias)} dias de retraso`;
+    }
+
+    return `${dias} dias`;
+  }
+
+  private actualizarValidacionesSegunDecision(decision: DecisionFormulario): void {
+    const causal = this.formulario.controls.causalDenegatoria;
+    const fundamento = this.formulario.controls.fundamentoLegal;
+
+    if (decision === 'DENEGAR') {
+      causal.setValidators([Validators.required]);
+      fundamento.setValidators([Validators.required, Validators.minLength(30)]);
+    } else {
+      causal.clearValidators();
+      fundamento.clearValidators();
+      causal.setValue('');
+      fundamento.setValue('');
+    }
+
+    causal.updateValueAndValidity({ emitEvent: false });
+    fundamento.updateValueAndValidity({ emitEvent: false });
+  }
+
+  private cargarSolicitudDesdeRuta(): void {
+    const expediente = this.route.snapshot.paramMap.get('expediente');
+    if (!expediente) {
+      this.loadingSolicitud.set(false);
+      this.error.set('No se recibio expediente para responder.');
+      return;
+    }
+
+    this.loadingSolicitud.set(true);
+    this.error.set(null);
+
+    this.solicitudService.findByExpediente(expediente).subscribe({
+      next: (solicitud) => {
+        this.solicitud.set(solicitud);
+        this.loadingSolicitud.set(false);
+      },
+      error: () => {
+        this.loadingSolicitud.set(false);
+        this.error.set('No se pudo cargar la solicitud para registrar la respuesta.');
+      },
+    });
+  }
+
+  private tieneRespuesta(solicitud: Solicitud): boolean {
+    return (
+      solicitud.estado === 'RESPONDIDA' ||
+      solicitud.estado === 'DENEGADA' ||
+      solicitud.estado === 'CONCLUIDA'
+    );
+  }
+
+  private esSilencioAdministrativo(solicitud: Solicitud): boolean {
+    const dias = this.obtenerDiasRestantes(solicitud);
+    const porEstado = solicitud.estado === 'VENCIDA';
+    const porDias = dias !== null && dias < 0;
+    const porSemaforo = solicitud.semaforo === 'NEGRO';
+
+    return porEstado || porDias || porSemaforo;
+  }
+
+  private formatearTamano(bytes: number): string {
+    if (bytes < 1024) {
+      return `${bytes} B`;
+    }
+
+    const kb = bytes / 1024;
+    if (kb < 1024) {
+      return `${kb.toFixed(1)} KB`;
+    }
+
+    const mb = kb / 1024;
+    return `${mb.toFixed(1)} MB`;
+  }
+}

--- a/transparencia-frontend/src/app/pages/funcionario/funcionario-solicitud-detalle.component.css
+++ b/transparencia-frontend/src/app/pages/funcionario/funcionario-solicitud-detalle.component.css
@@ -1,0 +1,78 @@
+:host {
+  display: block;
+}
+
+.summary-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  border: 1px solid var(--ceniza-claro);
+  border-radius: 0.85rem;
+  background: var(--blanco);
+  padding: 1rem;
+  box-shadow: var(--shadow-sm);
+}
+
+.summary-label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--niebla);
+}
+
+.summary-value {
+  font-size: 1.1rem;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.tab-bar {
+  display: flex;
+  overflow-x: auto;
+}
+
+.tab-button {
+  border: none;
+  border-bottom: 2px solid transparent;
+  background: transparent;
+  color: var(--niebla);
+  font-size: 0.86rem;
+  font-weight: 600;
+  padding: 0.85rem 1.15rem;
+  cursor: pointer;
+  transition: color 180ms ease, border-color 180ms ease;
+  white-space: nowrap;
+}
+
+.tab-button:hover {
+  color: var(--humo);
+}
+
+.tab-button.active {
+  color: var(--peru-rojo);
+  border-bottom-color: var(--peru-rojo);
+}
+
+.document-item {
+  align-items: center;
+  background: var(--nieve);
+  border: 1px solid var(--ceniza-claro);
+  border-radius: 0.85rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.75rem;
+}
+
+.icon-wrap {
+  align-items: center;
+  background: var(--blanco);
+  border: 1px solid var(--ceniza-claro);
+  border-radius: 0.65rem;
+  color: var(--peru-rojo);
+  display: flex;
+  height: 2.4rem;
+  justify-content: center;
+  width: 2.4rem;
+}

--- a/transparencia-frontend/src/app/pages/funcionario/funcionario-solicitud-detalle.component.html
+++ b/transparencia-frontend/src/app/pages/funcionario/funcionario-solicitud-detalle.component.html
@@ -1,0 +1,190 @@
+<div class="min-h-screen bg-(--nieve-calida)">
+  @if (loading()) {
+    <section class="bg-gradient-peru-hero px-4 pb-10 pt-24">
+      <div class="mx-auto max-w-7xl">
+        <h1 class="text-2xl font-semibold text-(--carbon)">Cargando detalle de solicitud...</h1>
+      </div>
+    </section>
+    <section class="mx-auto max-w-7xl px-4 py-14 text-center">
+      <div class="mx-auto h-10 w-10 animate-spin rounded-full border-4 border-(--ceniza) border-t-(--peru-rojo)"></div>
+    </section>
+  } @else if (error()) {
+    <section class="bg-gradient-peru-hero px-4 pb-10 pt-24">
+      <div class="mx-auto max-w-7xl">
+        <a
+          routerLink="/funcionario"
+          class="inline-flex items-center gap-2 text-sm text-(--humo) transition hover:text-(--carbon)"
+          style="text-decoration: none;"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m12 19-7-7 7-7"/><path d="M19 12H5"/></svg>
+          Volver al Dashboard
+        </a>
+      </div>
+    </section>
+    <section class="mx-auto max-w-7xl px-4 pb-10">
+      <div class="alert-error">
+        <p>{{ error() }}</p>
+      </div>
+    </section>
+  } @else if (solicitud(); as solicitudData) {
+    <section class="bg-gradient-peru-hero px-4 pb-10 pt-24">
+      <div class="mx-auto max-w-7xl">
+        <a
+          routerLink="/funcionario"
+          class="inline-flex items-center gap-2 text-sm text-(--humo) transition hover:text-(--carbon)"
+          style="text-decoration: none;"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m12 19-7-7 7-7"/><path d="M19 12H5"/></svg>
+          Volver al Dashboard
+        </a>
+
+        <div class="mt-4 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <p class="text-sm font-semibold uppercase tracking-[0.08em] text-(--niebla)">HU-03 · FE-02</p>
+            <h1 class="mt-1 text-3xl font-extrabold text-(--carbon)">Detalle de Solicitud</h1>
+            <p class="mt-1 font-expediente text-sm text-(--humo)">{{ solicitudData.expediente }}</p>
+          </div>
+
+          <div class="flex items-center gap-2">
+            <span class="inline-flex rounded-full px-3 py-1 text-xs font-semibold" [class]="obtenerEstadoClase(solicitudData.estado)">
+              {{ solicitudData.estado }}
+            </span>
+            @if (puedeResponder(solicitudData)) {
+              <a
+                [routerLink]="['/funcionario/responder', solicitudData.expediente]"
+                class="btn-primary h-9 px-4 text-xs"
+                style="text-decoration: none;"
+              >
+                Responder
+              </a>
+            }
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="mx-auto -mt-5 max-w-7xl px-4 pb-10">
+      <div class="grid grid-cols-2 gap-3 md:grid-cols-4">
+        <article class="summary-card">
+          <span class="summary-label">Fecha solicitud</span>
+          <span class="summary-value text-(--estado-azul)">
+            @if (solicitudData.fechaPresentacion) {
+              {{ solicitudData.fechaPresentacion | date: 'dd/MM/yyyy' }}
+            } @else {
+              -
+            }
+          </span>
+        </article>
+
+        <article class="summary-card">
+          <span class="summary-label">Fecha limite</span>
+          <span class="summary-value text-(--estado-ambar)">
+            @if (solicitudData.fechaLimite) {
+              {{ solicitudData.fechaLimite | date: 'dd/MM/yyyy' }}
+            } @else {
+              -
+            }
+          </span>
+        </article>
+
+        <article class="summary-card">
+          <span class="summary-label">Dias restantes</span>
+          <span class="summary-value" [class]="obtenerDiasRestantes(solicitudData) !== null && obtenerDiasRestantes(solicitudData)! < 0 ? 'text-(--estado-rojo)' : 'text-(--estado-verde)'">
+            {{ obtenerTextoDiasRestantes(solicitudData) }}
+          </span>
+        </article>
+
+        <article class="summary-card">
+          <span class="summary-label">Semaforo</span>
+          <span class="inline-flex w-fit rounded-full px-2.5 py-1 text-xs font-semibold" [class]="obtenerSemaforoClase(solicitudData)">
+            {{ obtenerSemaforoEtiqueta(solicitudData) }}
+          </span>
+        </article>
+      </div>
+
+      <div class="card mt-5 overflow-hidden">
+        <div class="tab-bar border-b border-(--ceniza-claro)">
+          <button type="button" class="tab-button" [class.active]="activeTab() === 'informacion'" (click)="seleccionarTab('informacion')">
+            Informacion
+          </button>
+          <button type="button" class="tab-button" [class.active]="activeTab() === 'documentos'" (click)="seleccionarTab('documentos')">
+            Documentos
+          </button>
+          <button type="button" class="tab-button" [class.active]="activeTab() === 'historial'" (click)="seleccionarTab('historial')">
+            Historial
+          </button>
+        </div>
+
+        <div class="p-5 md:p-6">
+          @if (activeTab() === 'informacion') {
+            <div class="grid grid-cols-1 gap-5 md:grid-cols-2">
+              <div>
+                <p class="summary-label">Entidad responsable</p>
+                <p class="mt-1 text-sm text-(--carbon)">{{ solicitudData.entidadNombre || 'No especificada' }}</p>
+              </div>
+              <div>
+                <p class="summary-label">Tipo de informacion</p>
+                <p class="mt-1 text-sm text-(--carbon)">{{ solicitudData.tipoInformacion || 'No especificado' }}</p>
+              </div>
+              <div class="md:col-span-2">
+                <p class="summary-label">Asunto</p>
+                <p class="mt-1 text-sm font-semibold text-(--carbon)">{{ solicitudData.asunto }}</p>
+              </div>
+              <div class="md:col-span-2">
+                <p class="summary-label">Descripcion</p>
+                <p class="mt-1 whitespace-pre-wrap text-sm text-(--humo)">{{ solicitudData.descripcion }}</p>
+              </div>
+            </div>
+          }
+
+          @if (activeTab() === 'documentos') {
+            @if (documentos().length === 0) {
+              <div class="py-10 text-center">
+                <p class="text-sm text-(--niebla)">No hay documentos adjuntos para esta solicitud.</p>
+              </div>
+            } @else {
+              <div class="space-y-3">
+                @for (documento of documentos(); track documento.nombre) {
+                  <article class="document-item">
+                    <div class="flex items-center gap-3">
+                      <div class="icon-wrap">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"/><polyline points="14 2 14 8 20 8"/><line x1="16" x2="8" y1="13" y2="13"/><line x1="16" x2="8" y1="17" y2="17"/><line x1="10" x2="8" y1="9" y2="9"/></svg>
+                      </div>
+                      <div>
+                        <p class="text-sm font-semibold text-(--carbon)">{{ documento.nombre }}</p>
+                        <p class="text-xs text-(--niebla)">{{ documento.tipo }} · {{ documento.tamano }}</p>
+                      </div>
+                    </div>
+                    <button type="button" class="btn-outline h-9 px-3 text-xs" disabled>
+                      Descargar
+                    </button>
+                  </article>
+                }
+              </div>
+            }
+          }
+
+          @if (activeTab() === 'historial') {
+            <div class="space-y-5">
+              @for (evento of historial(); track evento.titulo + evento.descripcion) {
+                <article class="flex items-start gap-3">
+                  <span
+                    class="mt-1 inline-flex h-3 w-3 rounded-full ring-4"
+                    [class]="obtenerTonoPuntoClase(evento.tono) + ' ' + obtenerTonoAnilloClase(evento.tono)"
+                  ></span>
+                  <div>
+                    <p class="text-sm font-semibold text-(--carbon)">{{ evento.titulo }}</p>
+                    @if (evento.fecha) {
+                      <p class="text-xs text-(--niebla)">{{ evento.fecha | date: 'dd/MM/yyyy' }}</p>
+                    }
+                    <p class="mt-1 text-sm text-(--humo)">{{ evento.descripcion }}</p>
+                  </div>
+                </article>
+              }
+            </div>
+          }
+        </div>
+      </div>
+    </section>
+  }
+</div>

--- a/transparencia-frontend/src/app/pages/funcionario/funcionario-solicitud-detalle.component.ts
+++ b/transparencia-frontend/src/app/pages/funcionario/funcionario-solicitud-detalle.component.ts
@@ -1,0 +1,284 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { DatePipe } from '@angular/common';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import { Solicitud } from '../../models/solicitud.model';
+import { SolicitudService } from '../../services/solicitud.service';
+
+type TabDetalle = 'informacion' | 'documentos' | 'historial';
+type HistorialTono = 'info' | 'warning' | 'success' | 'muted';
+
+interface DocumentoVista {
+  nombre: string;
+  tipo: string;
+  tamano: string;
+}
+
+interface HistorialEvento {
+  titulo: string;
+  descripcion: string;
+  fecha?: string;
+  tono: HistorialTono;
+}
+
+@Component({
+  selector: 'app-funcionario-solicitud-detalle',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [RouterLink, DatePipe],
+  templateUrl: './funcionario-solicitud-detalle.component.html',
+  styleUrl: './funcionario-solicitud-detalle.component.css',
+})
+export class FuncionarioSolicitudDetalleComponent {
+  private readonly route = inject(ActivatedRoute);
+  private readonly solicitudService = inject(SolicitudService);
+
+  readonly loading = signal(true);
+  readonly error = signal<string | null>(null);
+  readonly solicitud = signal<Solicitud | null>(null);
+  readonly activeTab = signal<TabDetalle>('informacion');
+
+  readonly documentos = computed<DocumentoVista[]>(() => {
+    const solicitud = this.solicitud();
+    if (!solicitud) {
+      return [];
+    }
+
+    const documentos: DocumentoVista[] = [];
+
+    if (solicitud.formatoDigital) {
+      documentos.push({
+        nombre: 'formato-digital-solicitado.txt',
+        tipo: 'TXT',
+        tamano: '1 KB',
+      });
+    }
+
+    if (solicitud.formatoFisico) {
+      documentos.push({
+        nombre: 'formato-fisico-solicitado.txt',
+        tipo: 'TXT',
+        tamano: '1 KB',
+      });
+    }
+
+    if (solicitud.tipoInformacion) {
+      documentos.push({
+        nombre: 'tipo-informacion-solicitada.txt',
+        tipo: 'TXT',
+        tamano: '1 KB',
+      });
+    }
+
+    return documentos;
+  });
+
+  readonly historial = computed<HistorialEvento[]>(() => {
+    const solicitud = this.solicitud();
+    if (!solicitud) {
+      return [];
+    }
+
+    const eventos: HistorialEvento[] = [
+      {
+        titulo: 'Solicitud recepcionada',
+        descripcion: 'Se registro la solicitud SAIP y fue asignada a la entidad.',
+        fecha: solicitud.fechaPresentacion,
+        tono: 'info',
+      },
+    ];
+
+    if (solicitud.estado === 'EN_REVISION' || solicitud.estado === 'PENDIENTE_INFORMACION') {
+      eventos.push({
+        titulo: 'Solicitud en revision',
+        descripcion: 'El funcionario esta evaluando la informacion solicitada.',
+        tono: 'warning',
+      });
+    }
+
+    if (this.tieneRespuesta(solicitud)) {
+      eventos.push({
+        titulo: 'Respuesta registrada',
+        descripcion: 'La entidad emitio respuesta a la solicitud.',
+        tono: 'success',
+      });
+    }
+
+    if (this.esSilencioAdministrativo(solicitud)) {
+      eventos.push({
+        titulo: 'Silencio administrativo',
+        descripcion: 'La solicitud excedio el plazo legal de respuesta.',
+        fecha: solicitud.fechaLimite,
+        tono: 'muted',
+      });
+    }
+
+    return eventos;
+  });
+
+  constructor() {
+    this.cargarSolicitudDesdeRuta();
+  }
+
+  seleccionarTab(tab: TabDetalle): void {
+    this.activeTab.set(tab);
+  }
+
+  puedeResponder(solicitud: Solicitud): boolean {
+    return !this.esSilencioAdministrativo(solicitud) && !this.tieneRespuesta(solicitud);
+  }
+
+  obtenerSemaforoEtiqueta(solicitud: Solicitud): string {
+    if (this.esSilencioAdministrativo(solicitud)) {
+      return 'NEGRO';
+    }
+
+    const dias = this.obtenerDiasRestantes(solicitud);
+    if (dias === null) {
+      return 'N/A';
+    }
+    if (dias >= 5) {
+      return 'VERDE';
+    }
+    if (dias >= 2) {
+      return 'AMBAR';
+    }
+    if (dias >= 0) {
+      return 'ROJO';
+    }
+
+    return 'NEGRO';
+  }
+
+  obtenerSemaforoClase(solicitud: Solicitud): string {
+    const etiqueta = this.obtenerSemaforoEtiqueta(solicitud);
+
+    if (etiqueta === 'VERDE') {
+      return 'bg-emerald-100 text-emerald-700 border border-emerald-200';
+    }
+    if (etiqueta === 'AMBAR') {
+      return 'bg-amber-100 text-amber-700 border border-amber-200';
+    }
+    if (etiqueta === 'ROJO') {
+      return 'bg-red-100 text-red-700 border border-red-200';
+    }
+    if (etiqueta === 'NEGRO') {
+      return 'bg-neutral-800 text-white border border-neutral-700';
+    }
+
+    return 'bg-neutral-100 text-neutral-700 border border-neutral-200';
+  }
+
+  obtenerEstadoClase(estado: string): string {
+    if (estado === 'RESPONDIDA' || estado === 'CONCLUIDA') {
+      return 'bg-emerald-100 text-emerald-700 border border-emerald-200';
+    }
+
+    if (estado === 'DENEGADA') {
+      return 'bg-red-100 text-red-700 border border-red-200';
+    }
+
+    if (estado === 'VENCIDA') {
+      return 'bg-neutral-800 text-white border border-neutral-700';
+    }
+
+    if (estado === 'EN_REVISION') {
+      return 'bg-blue-100 text-blue-700 border border-blue-200';
+    }
+
+    return 'bg-amber-100 text-amber-700 border border-amber-200';
+  }
+
+  obtenerTonoPuntoClase(tono: HistorialTono): string {
+    if (tono === 'success') {
+      return 'bg-emerald-500';
+    }
+
+    if (tono === 'warning') {
+      return 'bg-amber-500';
+    }
+
+    if (tono === 'muted') {
+      return 'bg-neutral-500';
+    }
+
+    return 'bg-blue-500';
+  }
+
+  obtenerTonoAnilloClase(tono: HistorialTono): string {
+    if (tono === 'success') {
+      return 'ring-emerald-100';
+    }
+
+    if (tono === 'warning') {
+      return 'ring-amber-100';
+    }
+
+    if (tono === 'muted') {
+      return 'ring-neutral-200';
+    }
+
+    return 'ring-blue-100';
+  }
+
+  obtenerDiasRestantes(solicitud: Solicitud): number | null {
+    return typeof solicitud.diasRestantes === 'number' ? solicitud.diasRestantes : null;
+  }
+
+  obtenerTextoDiasRestantes(solicitud: Solicitud): string {
+    const dias = this.obtenerDiasRestantes(solicitud);
+    if (dias === null) {
+      return 'No disponible';
+    }
+
+    if (dias < 0) {
+      return `${Math.abs(dias)} dias de retraso`;
+    }
+
+    return `${dias} dias`;
+  }
+
+  private cargarSolicitudDesdeRuta(): void {
+    const expediente = this.route.snapshot.paramMap.get('expediente');
+    if (!expediente) {
+      this.loading.set(false);
+      this.error.set('No se recibio expediente para mostrar el detalle.');
+      return;
+    }
+
+    this.loading.set(true);
+    this.error.set(null);
+
+    this.solicitudService.findByExpediente(expediente).subscribe({
+      next: (solicitud) => {
+        this.solicitud.set(solicitud);
+        this.loading.set(false);
+      },
+      error: () => {
+        this.loading.set(false);
+        this.error.set('No se pudo cargar la solicitud seleccionada.');
+      },
+    });
+  }
+
+  private tieneRespuesta(solicitud: Solicitud): boolean {
+    return (
+      solicitud.estado === 'RESPONDIDA' ||
+      solicitud.estado === 'DENEGADA' ||
+      solicitud.estado === 'CONCLUIDA'
+    );
+  }
+
+  private esSilencioAdministrativo(solicitud: Solicitud): boolean {
+    const dias = this.obtenerDiasRestantes(solicitud);
+    const porEstado = solicitud.estado === 'VENCIDA';
+    const porDias = dias !== null && dias < 0;
+    const porSemaforo = solicitud.semaforo === 'NEGRO';
+
+    return porEstado || porDias || porSemaforo;
+  }
+}


### PR DESCRIPTION
## Contexto
La HU-03 en frontend requería completar FE-02 para que el funcionario pueda revisar una solicitud en una vista de detalle y emitir respuesta con flujo guiado (aceptar/denegar), antes de integrar llamadas reales de `RespuestaService` en FE-03.

## Cambios incluidos
- Se agregó `funcionario-solicitud-detalle` con tabs de `Informacion`, `Documentos` e `Historial`.
- Se agregó `funcionario-responder` con formulario reactivo, selector `ACEPTAR`/`DENEGAR`, validaciones condicionales y preview de archivos adjuntos.
- Se incorporaron rutas lazy:
  - `/funcionario/solicitud/:expediente`
  - `/funcionario/responder/:expediente`
- Se actualizó el dashboard de funcionario para navegar a `Detalle` y `Responder` según reglas de estado.

## Trazabilidad de sub-issues
- [x] Refs #33
  - `1a2a613` — detalle de solicitud y navegación inicial.
- [x] Closes #33
  - `1c68641` — formulario de respuesta e integración final de rutas/acciones.

## Validación
- `npm test -- --watch=false` -> 20 tests en verde.
- `npm run build` -> compilación exitosa.

## Riesgos y mitigaciones
- Riesgo: FE-02 aún no persiste respuesta en backend (eso corresponde a FE-03).
- Mitigación: el formulario valida flujo y deja preparado el contrato de interacción para integrar `RespuestaService` en el siguiente sub-issue.

## Checklist de revisión
- [x] Alcance limitado a HU-03 · FE-02.
- [x] Commits atómicos por responsabilidad.
- [x] Sin cambios en backend.
- [x] Frontend tests y build en verde.