### PR TITLE
🔀 feat(HU-03): integrar respuesta SAIP del funcionario con API

### DIFF
--- a/transparencia-frontend/src/app/models/respuesta.model.ts
+++ b/transparencia-frontend/src/app/models/respuesta.model.ts
@@ -1,0 +1,28 @@
+export type TipoRespuesta =
+  | 'ENTREGA_TOTAL'
+  | 'ENTREGA_PARCIAL'
+  | 'DENEGACION_TOTAL'
+  | 'SILENCIO_ADMINISTRATIVO';
+
+export interface Respuesta {
+  id: number;
+  tipoRespuesta?: TipoRespuesta | null;
+  decision?: string | null;
+  contenido?: string | null;
+  causalDenegatoria?: string | null;
+  fundamentoLegal?: string | null;
+  fechaRespuesta?: string | null;
+  funcionarioId?: number | null;
+  funcionarioNombre?: string | null;
+}
+
+export interface CrearRespuestaRequest {
+  solicitudId: number;
+  funcionarioId: number;
+  tipoRespuesta: TipoRespuesta;
+  contenido: string;
+  causalDenegatoria?: string | null;
+  fundamentoLegal?: string | null;
+  formatoEntrega?: string | null;
+  plazoEntrega?: number | null;
+}

--- a/transparencia-frontend/src/app/models/solicitud.model.ts
+++ b/transparencia-frontend/src/app/models/solicitud.model.ts
@@ -1,3 +1,5 @@
+import { Respuesta } from './respuesta.model';
+
 export type EstadoSolicitud =
   | 'RECEPCIONADA'
   | 'EN_REVISION'
@@ -29,6 +31,7 @@ export interface Solicitud {
   entidadId?: number;
   ciudadanoNombre?: string;
   entidadNombre?: string;
+  respuesta?: Respuesta | null;
   diasRestantes?: number;
   semaforo?: SemaforoEstado;
 }

--- a/transparencia-frontend/src/app/pages/funcionario/funcionario-dashboard.component.html
+++ b/transparencia-frontend/src/app/pages/funcionario/funcionario-dashboard.component.html
@@ -1,7 +1,6 @@
 <div class="min-h-screen bg-(--nieve-calida)">
   <section class="bg-gradient-peru-hero px-4 pb-10 pt-24">
     <div class="mx-auto max-w-7xl">
-      <p class="text-sm font-semibold uppercase tracking-[0.08em] text-(--niebla)">HU-03 · FE-01</p>
       <h1 class="mt-2 text-3xl font-extrabold text-(--carbon)">Dashboard de Funcionario</h1>
       <p class="mt-1 text-sm text-(--humo)">{{ entidadNombre() }}</p>
     </div>

--- a/transparencia-frontend/src/app/pages/funcionario/funcionario-responder.component.html
+++ b/transparencia-frontend/src/app/pages/funcionario/funcionario-responder.component.html
@@ -161,7 +161,7 @@
                   <label class="label" for="causal">Causal de denegatoria <span class="text-(--estado-rojo)">*</span></label>
                   <select id="causal" class="input" formControlName="causalDenegatoria">
                     <option value="">Seleccione causal</option>
-                    @for (causal of causalesDenegacion; track causal) {
+                    @for (causal of causalesDenegacion(); track causal) {
                       <option [value]="causal">{{ causal }}</option>
                     }
                   </select>

--- a/transparencia-frontend/src/app/pages/funcionario/funcionario-responder.component.ts
+++ b/transparencia-frontend/src/app/pages/funcionario/funcionario-responder.component.ts
@@ -1,21 +1,33 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  PLATFORM_ID,
   computed,
   inject,
   signal,
 } from '@angular/core';
-import { DatePipe } from '@angular/common';
+import { DatePipe, isPlatformBrowser } from '@angular/common';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { Solicitud } from '../../models/solicitud.model';
+import { CrearRespuestaRequest } from '../../models/respuesta.model';
+import { RespuestaService } from '../../services/respuesta.service';
 import { SolicitudService } from '../../services/solicitud.service';
+import {
+  canSendManualResponse,
+  isSilencioAdministrativo,
+} from '../../utils/silencio-administrativo.util';
 
 type DecisionFormulario = 'ACEPTAR' | 'DENEGAR';
 
 interface ArchivoPreview {
   nombre: string;
   tamano: string;
+}
+
+interface SesionFuncionario {
+  funcionarioId?: number;
+  usuarioId?: number;
 }
 
 @Component({
@@ -28,6 +40,8 @@ interface ArchivoPreview {
 export class FuncionarioResponderComponent {
   private readonly route = inject(ActivatedRoute);
   private readonly solicitudService = inject(SolicitudService);
+  private readonly respuestaService = inject(RespuestaService);
+  private readonly platformId = inject(PLATFORM_ID);
   private readonly fb = inject(FormBuilder);
 
   readonly loading = signal(false);
@@ -37,7 +51,8 @@ export class FuncionarioResponderComponent {
   readonly solicitud = signal<Solicitud | null>(null);
   readonly archivosAdjuntos = signal<File[]>([]);
 
-  readonly causalesDenegacion = [
+  readonly causalesDenegacion = signal<string[]>([]);
+  private readonly causalesFallback = [
     'Informacion confidencial',
     'Informacion reservada',
     'Informacion secreta',
@@ -62,7 +77,7 @@ export class FuncionarioResponderComponent {
       return false;
     }
 
-    return !this.esSilencioAdministrativo(solicitud) && !this.tieneRespuesta(solicitud);
+    return canSendManualResponse(this.construirContexto(solicitud));
   });
 
   readonly previewArchivos = computed<ArchivoPreview[]>(() =>
@@ -78,6 +93,7 @@ export class FuncionarioResponderComponent {
     });
 
     this.actualizarValidacionesSegunDecision(this.formulario.controls.decision.value);
+    this.cargarCausalesDenegacion();
     this.cargarSolicitudDesdeRuta();
   }
 
@@ -97,6 +113,12 @@ export class FuncionarioResponderComponent {
     this.error.set(null);
     this.mensaje.set(null);
 
+    const solicitud = this.solicitud();
+    if (!solicitud) {
+      this.error.set('No se encontro la solicitud para registrar la respuesta.');
+      return;
+    }
+
     if (!this.puedeRegistrarRespuesta()) {
       this.error.set('No se permite registrar respuesta manual para esta solicitud.');
       return;
@@ -114,16 +136,61 @@ export class FuncionarioResponderComponent {
       return;
     }
 
+    const funcionarioId = this.obtenerFuncionarioIdDesdeSesion();
+    if (funcionarioId === null) {
+      this.error.set('No se pudo obtener el funcionario desde la sesion.');
+      return;
+    }
+
     this.loading.set(true);
 
-    setTimeout(() => {
-      this.loading.set(false);
-      this.mensaje.set(
-        this.formulario.controls.decision.value === 'ACEPTAR'
-          ? 'Respuesta de aceptacion validada. Lista para integracion con API en FE-03.'
-          : 'Respuesta de denegacion validada. Lista para integracion con API en FE-03.',
-      );
-    }, 450);
+    const contenido = this.formulario.controls.contenido.value.trim();
+    const decision = this.formulario.controls.decision.value;
+
+    if (decision === 'ACEPTAR') {
+      const payload: CrearRespuestaRequest = {
+        solicitudId: solicitud.idSolicitud,
+        funcionarioId,
+        tipoRespuesta: 'ENTREGA_TOTAL',
+        contenido,
+        formatoEntrega: 'DIGITAL',
+        plazoEntrega: 5,
+      };
+
+      this.respuestaService.aceptarSolicitud(payload).subscribe({
+        next: () => {
+          this.loading.set(false);
+          this.mensaje.set('Respuesta de aceptacion enviada correctamente.');
+        },
+        error: (errorResponse) => {
+          this.loading.set(false);
+          const mensaje = errorResponse?.error?.mensaje as string | undefined;
+          this.error.set(mensaje ?? 'No se pudo enviar la respuesta de aceptacion.');
+        },
+      });
+      return;
+    }
+
+    const payload: CrearRespuestaRequest = {
+      solicitudId: solicitud.idSolicitud,
+      funcionarioId,
+      tipoRespuesta: 'DENEGACION_TOTAL',
+      contenido,
+      causalDenegatoria: this.formulario.controls.causalDenegatoria.value?.trim() || null,
+      fundamentoLegal: this.formulario.controls.fundamentoLegal.value?.trim() || null,
+    };
+
+    this.respuestaService.denegarSolicitud(payload).subscribe({
+      next: () => {
+        this.loading.set(false);
+        this.mensaje.set('Respuesta de denegacion enviada correctamente.');
+      },
+      error: (errorResponse) => {
+        this.loading.set(false);
+        const mensaje = errorResponse?.error?.mensaje as string | undefined;
+        this.error.set(mensaje ?? 'No se pudo enviar la respuesta de denegacion.');
+      },
+    });
   }
 
   obtenerEstadoClase(estado: string): string {
@@ -209,21 +276,64 @@ export class FuncionarioResponderComponent {
     });
   }
 
+  private cargarCausalesDenegacion(): void {
+    this.respuestaService.getCausalesDenegacion().subscribe({
+      next: (causales) => {
+        this.causalesDenegacion.set(causales.length > 0 ? causales : this.causalesFallback);
+      },
+      error: () => {
+        this.causalesDenegacion.set(this.causalesFallback);
+      },
+    });
+  }
+
   private tieneRespuesta(solicitud: Solicitud): boolean {
-    return (
-      solicitud.estado === 'RESPONDIDA' ||
-      solicitud.estado === 'DENEGADA' ||
-      solicitud.estado === 'CONCLUIDA'
-    );
+    if (solicitud.respuesta?.tipoRespuesta) {
+      return true;
+    }
+
+    return solicitud.estado === 'RESPONDIDA' || solicitud.estado === 'DENEGADA' || solicitud.estado === 'CONCLUIDA';
   }
 
   private esSilencioAdministrativo(solicitud: Solicitud): boolean {
-    const dias = this.obtenerDiasRestantes(solicitud);
-    const porEstado = solicitud.estado === 'VENCIDA';
-    const porDias = dias !== null && dias < 0;
-    const porSemaforo = solicitud.semaforo === 'NEGRO';
+    const porSemaforo = solicitud.semaforo === 'NEGRO' && !solicitud.respuesta?.tipoRespuesta;
+    return isSilencioAdministrativo(this.construirContexto(solicitud)) || porSemaforo;
+  }
 
-    return porEstado || porDias || porSemaforo;
+  private construirContexto(solicitud: Solicitud) {
+    return {
+      estado: solicitud.estado,
+      diasRestantes: solicitud.diasRestantes,
+      respuesta: solicitud.respuesta
+        ? {
+            tipoRespuesta: solicitud.respuesta.tipoRespuesta,
+          }
+        : null,
+    };
+  }
+
+  private obtenerFuncionarioIdDesdeSesion(): number | null {
+    if (!isPlatformBrowser(this.platformId)) {
+      return null;
+    }
+
+    const rawSesion = localStorage.getItem('usuario');
+    if (!rawSesion) {
+      return null;
+    }
+
+    try {
+      const sesion = JSON.parse(rawSesion) as SesionFuncionario;
+      if (typeof sesion.funcionarioId === 'number') {
+        return sesion.funcionarioId;
+      }
+      if (typeof sesion.usuarioId === 'number') {
+        return sesion.usuarioId;
+      }
+      return null;
+    } catch {
+      return null;
+    }
   }
 
   private formatearTamano(bytes: number): string {

--- a/transparencia-frontend/src/app/services/respuesta.service.spec.ts
+++ b/transparencia-frontend/src/app/services/respuesta.service.spec.ts
@@ -1,0 +1,114 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { RespuestaService } from './respuesta.service';
+import { CrearRespuestaRequest } from '../models/respuesta.model';
+
+describe('RespuestaService', () => {
+  let service: RespuestaService;
+  let httpMock: HttpTestingController;
+
+  const apiUrl = 'http://localhost:8080/api/respuestas';
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+
+    service = TestBed.inject(RespuestaService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('deberia crear el servicio', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('deberia obtener todas las respuestas con GET /api/respuestas', () => {
+    service.findAll().subscribe((respuestas) => {
+      expect(respuestas.length).toBe(1);
+      expect(respuestas[0]?.id).toBe(10);
+    });
+
+    const req = httpMock.expectOne(apiUrl);
+    expect(req.request.method).toBe('GET');
+    req.flush([{ id: 10, tipoRespuesta: 'ENTREGA_TOTAL' }]);
+  });
+
+  it('deberia obtener una respuesta por id con GET /api/respuestas/{id}', () => {
+    service.findById(4).subscribe((respuesta) => {
+      expect(respuesta.id).toBe(4);
+    });
+
+    const req = httpMock.expectOne(`${apiUrl}/4`);
+    expect(req.request.method).toBe('GET');
+    req.flush({ id: 4 });
+  });
+
+  it('deberia obtener una respuesta por solicitud con GET /api/respuestas/solicitud/{id}', () => {
+    service.findBySolicitudId(8).subscribe((respuesta) => {
+      expect(respuesta.id).toBe(11);
+    });
+
+    const req = httpMock.expectOne(`${apiUrl}/solicitud/8`);
+    expect(req.request.method).toBe('GET');
+    req.flush({ id: 11 });
+  });
+
+  it('deberia aceptar solicitud con POST /api/respuestas/aceptar', () => {
+    const payload: CrearRespuestaRequest = {
+      solicitudId: 1,
+      funcionarioId: 2,
+      tipoRespuesta: 'ENTREGA_TOTAL',
+      contenido: 'Se entrega la informacion solicitada',
+      formatoEntrega: 'DIGITAL',
+      plazoEntrega: 5,
+    };
+
+    service.aceptarSolicitud(payload).subscribe();
+
+    const req = httpMock.expectOne(`${apiUrl}/aceptar`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual(payload);
+    req.flush({ id: 12, tipoRespuesta: 'ENTREGA_TOTAL' });
+  });
+
+  it('deberia denegar solicitud con POST /api/respuestas/denegar', () => {
+    const payload: CrearRespuestaRequest = {
+      solicitudId: 1,
+      funcionarioId: 2,
+      tipoRespuesta: 'DENEGACION_TOTAL',
+      contenido: 'No procede por causal legal',
+      causalDenegatoria: 'Informacion reservada',
+      fundamentoLegal: 'Art. 15-B Ley 27806',
+    };
+
+    service.denegarSolicitud(payload).subscribe();
+
+    const req = httpMock.expectOne(`${apiUrl}/denegar`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual(payload);
+    req.flush({ id: 13, tipoRespuesta: 'DENEGACION_TOTAL' });
+  });
+
+  it('deberia listar causales con GET /api/respuestas/causales-denegacion', () => {
+    const causalesEsperadas = [
+      'Informacion Confidencial - Art. 15 Ley 27806',
+      'Informacion Secreta - Art. 15-A Ley 27806',
+    ];
+
+    service.getCausalesDenegacion().subscribe((causales) => {
+      expect(causales).toEqual(causalesEsperadas);
+    });
+
+    const req = httpMock.expectOne(`${apiUrl}/causales-denegacion`);
+    expect(req.request.method).toBe('GET');
+    req.flush(causalesEsperadas);
+  });
+});

--- a/transparencia-frontend/src/app/services/respuesta.service.ts
+++ b/transparencia-frontend/src/app/services/respuesta.service.ts
@@ -1,0 +1,34 @@
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { CrearRespuestaRequest, Respuesta } from '../models/respuesta.model';
+
+@Injectable({ providedIn: 'root' })
+export class RespuestaService {
+  private readonly http = inject(HttpClient);
+  private readonly apiUrl = 'http://localhost:8080/api/respuestas';
+
+  findAll(): Observable<Respuesta[]> {
+    return this.http.get<Respuesta[]>(this.apiUrl);
+  }
+
+  findById(id: number): Observable<Respuesta> {
+    return this.http.get<Respuesta>(`${this.apiUrl}/${id}`);
+  }
+
+  findBySolicitudId(solicitudId: number): Observable<Respuesta> {
+    return this.http.get<Respuesta>(`${this.apiUrl}/solicitud/${solicitudId}`);
+  }
+
+  aceptarSolicitud(data: CrearRespuestaRequest): Observable<Respuesta> {
+    return this.http.post<Respuesta>(`${this.apiUrl}/aceptar`, data);
+  }
+
+  denegarSolicitud(data: CrearRespuestaRequest): Observable<Respuesta> {
+    return this.http.post<Respuesta>(`${this.apiUrl}/denegar`, data);
+  }
+
+  getCausalesDenegacion(): Observable<string[]> {
+    return this.http.get<string[]>(`${this.apiUrl}/causales-denegacion`);
+  }
+}

--- a/transparencia-frontend/src/app/utils/silencio-administrativo.util.spec.ts
+++ b/transparencia-frontend/src/app/utils/silencio-administrativo.util.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import {
+  canSendManualResponse,
+  isSilencioAdministrativo,
+} from './silencio-administrativo.util';
+
+describe('silencio-administrativo util', () => {
+  it('detecta silencio administrativo por estado VENCIDA', () => {
+    expect(isSilencioAdministrativo({ estado: 'VENCIDA' })).toBe(true);
+  });
+
+  it('detecta silencio administrativo por diasRestantes negativos', () => {
+    expect(
+      isSilencioAdministrativo({
+        estado: 'EN_REVISION',
+        diasRestantes: -1,
+      }),
+    ).toBe(true);
+  });
+
+  it('detecta silencio administrativo por tipo de respuesta explicito', () => {
+    expect(
+      isSilencioAdministrativo({
+        estado: 'RESPONDIDA',
+        respuesta: { tipoRespuesta: 'SILENCIO_ADMINISTRATIVO' },
+      }),
+    ).toBe(true);
+  });
+
+  it('permite respuesta manual si no hay silencio ni respuesta previa', () => {
+    expect(
+      canSendManualResponse({
+        estado: 'EN_REVISION',
+        diasRestantes: 3,
+      }),
+    ).toBe(true);
+  });
+
+  it('bloquea respuesta manual si aplica silencio administrativo', () => {
+    expect(
+      canSendManualResponse({
+        estado: 'VENCIDA',
+        diasRestantes: -2,
+      }),
+    ).toBe(false);
+  });
+
+  it('bloquea respuesta manual si ya existe respuesta registrada', () => {
+    expect(
+      canSendManualResponse({
+        estado: 'RESPONDIDA',
+        respuesta: { tipoRespuesta: 'ENTREGA_TOTAL' },
+      }),
+    ).toBe(false);
+  });
+});

--- a/transparencia-frontend/src/app/utils/silencio-administrativo.util.ts
+++ b/transparencia-frontend/src/app/utils/silencio-administrativo.util.ts
@@ -1,0 +1,40 @@
+export interface SolicitudSilencioContext {
+  estado?: string | null;
+  diasRestantes?: number | null;
+  respuesta?: {
+    tipoRespuesta?: string | null;
+  } | null;
+}
+
+export function isSilencioAdministrativo(
+  context: SolicitudSilencioContext | null | undefined,
+): boolean {
+  if (!context) {
+    return false;
+  }
+
+  const tipoRespuesta = context.respuesta?.tipoRespuesta?.toUpperCase();
+  if (tipoRespuesta === 'SILENCIO_ADMINISTRATIVO') {
+    return true;
+  }
+
+  if ((context.estado ?? '').toUpperCase() === 'VENCIDA') {
+    return true;
+  }
+
+  return (context.diasRestantes ?? 0) < 0;
+}
+
+export function canSendManualResponse(
+  context: SolicitudSilencioContext | null | undefined,
+): boolean {
+  if (!context) {
+    return false;
+  }
+
+  if (isSilencioAdministrativo(context)) {
+    return false;
+  }
+
+  return !context.respuesta?.tipoRespuesta;
+}


### PR DESCRIPTION
## Contexto
El flujo FE-03 de HU-03 estaba incompleto en frontend: el formulario de respuesta de funcionario validaba localmente, pero no persistía en backend ni aplicaba de forma uniforme las reglas de silencio administrativo y respuesta previa.

## Cambios incluidos
- Se incorpora `RespuestaService` con los métodos del contrato backend (`findAll`, `findById`, `findBySolicitudId`, `aceptarSolicitud`, `denegarSolicitud`, `getCausalesDenegacion`).
- Se agregan modelos tipados `Respuesta` y `CrearRespuestaRequest`.
- Se crea utilitario `silencio-administrativo.util` para centralizar reglas de negocio de bloqueo/habilitación de respuesta manual.
- Se integra `FuncionarioResponderComponent` con API real para aceptar/denegar solicitudes.
- Se cargan causales de denegación desde API con fallback local.
- Se extiende el contrato `Solicitud` con referencia opcional a `respuesta`.
- Se corrige el encabezado del dashboard de funcionario eliminando la etiqueta visual `HU-03 · FE-01`.

## Trazabilidad de sub-issues
- [x] Refs #34 — commit `789eb0f` (base reusable: modelo, servicio, utilitario y pruebas)
- [x] Closes #34 — commit `7dc8c9b` (integración en formulario de funcionario y ajuste visual)

## Validación
- Frontend tests: `npm test -- --watch=false` -> 33/33 passing
- Frontend build: `npm run build` -> OK
- Auto-sync obligatorio ejecutado: `origin/develop...HEAD` con primer valor `0`

## Riesgos y mitigaciones
- Riesgo: diferencias de payload entre frontend y backend en producción.
- Mitigación: tipado estricto en `CrearRespuestaRequest` + pruebas HTTP del servicio.
- Riesgo: datos de sesión sin `funcionarioId` en localStorage.
- Mitigación: validación defensiva y mensaje de error controlado en UI.

## Checklist de revisión
- [ ] Confirmar que la denegación persiste causal y fundamento legal correctamente.
- [ ] Confirmar que solicitudes con silencio administrativo no permitan respuesta manual.
- [ ] Confirmar que el formulario acepta/deniega contra endpoints reales en entorno integrado.
- [ ] Verificar que no se muestre la etiqueta `HU-03 · FE-01` en dashboard de funcionario.