### PR TITLE
🔀 test(HU-03): fortalecer pruebas de respuesta y silencio administrativo

### DIFF
--- a/transparencia-frontend/src/app/services/respuesta.service.spec.ts
+++ b/transparencia-frontend/src/app/services/respuesta.service.spec.ts
@@ -111,4 +111,14 @@ describe('RespuestaService', () => {
     expect(req.request.method).toBe('GET');
     req.flush(causalesEsperadas);
   });
+
+  it('deberia retornar arreglo vacio cuando el backend no envia causales', () => {
+    service.getCausalesDenegacion().subscribe((causales) => {
+      expect(causales).toEqual([]);
+    });
+
+    const req = httpMock.expectOne(`${apiUrl}/causales-denegacion`);
+    expect(req.request.method).toBe('GET');
+    req.flush([]);
+  });
 });

--- a/transparencia-frontend/src/app/utils/silencio-administrativo.util.spec.ts
+++ b/transparencia-frontend/src/app/utils/silencio-administrativo.util.spec.ts
@@ -5,8 +5,25 @@ import {
 } from './silencio-administrativo.util';
 
 describe('silencio-administrativo util', () => {
+  it('retorna false cuando el contexto es null o undefined', () => {
+    expect(isSilencioAdministrativo(null)).toBe(false);
+    expect(isSilencioAdministrativo(undefined)).toBe(false);
+    expect(canSendManualResponse(null)).toBe(false);
+    expect(canSendManualResponse(undefined)).toBe(false);
+  });
+
   it('detecta silencio administrativo por estado VENCIDA', () => {
     expect(isSilencioAdministrativo({ estado: 'VENCIDA' })).toBe(true);
+  });
+
+  it('detecta silencio administrativo ignorando mayusculas/minusculas', () => {
+    expect(isSilencioAdministrativo({ estado: 'vencida' })).toBe(true);
+    expect(
+      isSilencioAdministrativo({
+        estado: 'respondida',
+        respuesta: { tipoRespuesta: 'silencio_administrativo' },
+      }),
+    ).toBe(true);
   });
 
   it('detecta silencio administrativo por diasRestantes negativos', () => {
@@ -52,5 +69,14 @@ describe('silencio-administrativo util', () => {
         respuesta: { tipoRespuesta: 'ENTREGA_TOTAL' },
       }),
     ).toBe(false);
+  });
+
+  it('permite respuesta manual si respuesta existe pero tipoRespuesta es vacio', () => {
+    expect(
+      canSendManualResponse({
+        estado: 'EN_REVISION',
+        respuesta: { tipoRespuesta: '' },
+      }),
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## Contexto
El sub-issue FE-04 de HU-03 exige reforzar la cobertura de pruebas para la integración de respuestas SAIP, especialmente en escenarios de borde del servicio HTTP y del utilitario de silencio administrativo.

## Cambios incluidos
- Se amplía `respuesta.service.spec.ts` con un caso adicional para validar comportamiento cuando `/causales-denegacion` retorna un arreglo vacío.
- Se amplía `silencio-administrativo.util.spec.ts` con escenarios de borde:
  - contexto `null` y `undefined`
  - evaluación case-insensitive de `estado` y `tipoRespuesta`
  - respuesta existente con `tipoRespuesta` vacío
- No se modificó lógica de producción; el alcance es exclusivamente de pruebas.

## Trazabilidad de sub-issues
- [x] Refs #35 — commit `2acd37d` (pruebas de RespuestaService)
- [x] Closes #35 — commit `0288274` (pruebas de silencio administrativo)

## Validación
- Frontend tests: `npm test -- --watch=false` -> 37/37 passing
- Frontend build: `npm run build` -> OK
- Auto-sync obligatorio ejecutado: `origin/develop...HEAD` con primer valor `0`

## Riesgos y mitigaciones
- Riesgo: falsos positivos por cambios futuros en contrato backend de causales.
- Mitigación: pruebas HTTP explícitas por endpoint y método.
- Riesgo: regresiones en reglas de silencio por variaciones de mayúsculas/minúsculas.
- Mitigación: nuevos casos case-insensitive en utilitario.

## Checklist de revisión
- [ ] Verificar que FE-04 no introduce cambios funcionales en componentes.
- [ ] Confirmar que los nuevos casos de borde reflejan las reglas de negocio de HU-03.
- [ ] Confirmar ejecución estable de tests frontend en CI.