### PR TITLE
🔀 feat(HU-01): FE-03 · Implementar guards e interceptor

### DIFF
--- a/transparencia-frontend/src/app/app.config.ts
+++ b/transparencia-frontend/src/app/app.config.ts
@@ -1,13 +1,14 @@
 import { ApplicationConfig, provideBrowserGlobalErrorListeners } from '@angular/core';
-import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { provideRouter } from '@angular/router';
 
 import { routes } from './app.routes';
+import { authInterceptor } from './interceptors/auth.interceptor';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
-    provideHttpClient(),
+    provideHttpClient(withInterceptors([authInterceptor])),
     provideRouter(routes)
   ]
 };

--- a/transparencia-frontend/src/app/app.routes.ts
+++ b/transparencia-frontend/src/app/app.routes.ts
@@ -1,4 +1,6 @@
 import { Routes } from '@angular/router';
+import { tipoUsuarioGuard } from './guards/auth.guard';
+
 export const routes: Routes = [
   {
     path: '',
@@ -32,43 +34,53 @@ export const routes: Routes = [
   {
     path: 'ciudadano',
     redirectTo: 'ciudadano/nueva-saip',
-    pathMatch: 'full'
+    pathMatch: 'full',
+    canActivate: [tipoUsuarioGuard('CIUDADANO')]
   },
   {
     path: 'ciudadano/nueva-saip',
-    loadComponent: () => import('./pages/ciudadano/nueva-saip.component').then(m => m.NuevaSaipComponent)
+    loadComponent: () => import('./pages/ciudadano/nueva-saip.component').then(m => m.NuevaSaipComponent),
+    canActivate: [tipoUsuarioGuard('CIUDADANO')]
   },
   {
     path: 'ciudadano/nueva-apelacion',
-    loadComponent: () => import('./pages/ciudadano/nueva-apelacion.component').then(m => m.NuevaApelacionComponent)
+    loadComponent: () => import('./pages/ciudadano/nueva-apelacion.component').then(m => m.NuevaApelacionComponent),
+    canActivate: [tipoUsuarioGuard('CIUDADANO')]
   },
   {
     path: 'ciudadano/subsanacion',
-    loadComponent: () => import('./pages/ciudadano/subsanacion.component').then(m => m.SubsanacionComponent)
+    loadComponent: () => import('./pages/ciudadano/subsanacion.component').then(m => m.SubsanacionComponent),
+    canActivate: [tipoUsuarioGuard('CIUDADANO')]
   },
   {
     path: 'funcionario',
-    loadComponent: () => import('./pages/funcionario/funcionario-dashboard.component').then(m => m.FuncionarioDashboardComponent)
+    loadComponent: () => import('./pages/funcionario/funcionario-dashboard.component').then(m => m.FuncionarioDashboardComponent),
+    canActivate: [tipoUsuarioGuard('FUNCIONARIO')]
   },
   {
     path: 'funcionario/solicitud/:expediente',
-    loadComponent: () => import('./pages/funcionario/funcionario-solicitud-detalle.component').then(m => m.FuncionarioSolicitudDetalleComponent)
+    loadComponent: () => import('./pages/funcionario/funcionario-solicitud-detalle.component').then(m => m.FuncionarioSolicitudDetalleComponent),
+    canActivate: [tipoUsuarioGuard('FUNCIONARIO')]
   },
   {
     path: 'funcionario/responder/:expediente',
-    loadComponent: () => import('./pages/funcionario/funcionario-responder.component').then(m => m.FuncionarioResponderComponent)
+    loadComponent: () => import('./pages/funcionario/funcionario-responder.component').then(m => m.FuncionarioResponderComponent),
+    canActivate: [tipoUsuarioGuard('FUNCIONARIO')]
   },
   {
     path: 'ttaip',
-    loadComponent: () => import('./pages/ttaip/ttaip-dashboard.component').then(m => m.TtaipDashboardComponent)
+    loadComponent: () => import('./pages/ttaip/ttaip-dashboard.component').then(m => m.TtaipDashboardComponent),
+    canActivate: [tipoUsuarioGuard('TTAIP')]
   },
   {
     path: 'ttaip/segunda-calificacion',
-    loadComponent: () => import('./pages/ttaip/ttaip-segunda-calificacion.component').then(m => m.TtaipSegundaCalificacionComponent)
+    loadComponent: () => import('./pages/ttaip/ttaip-segunda-calificacion.component').then(m => m.TtaipSegundaCalificacionComponent),
+    canActivate: [tipoUsuarioGuard('TTAIP')]
   },
   {
     path: 'ttaip/segunda-calificacion/:expediente',
-    loadComponent: () => import('./pages/ttaip/ttaip-segunda-calificacion.component').then(m => m.TtaipSegundaCalificacionComponent)
+    loadComponent: () => import('./pages/ttaip/ttaip-segunda-calificacion.component').then(m => m.TtaipSegundaCalificacionComponent),
+    canActivate: [tipoUsuarioGuard('TTAIP')]
   },
   { path: '**', redirectTo: 'login' }
 ];

--- a/transparencia-frontend/src/app/guards/auth.guard.ts
+++ b/transparencia-frontend/src/app/guards/auth.guard.ts
@@ -1,0 +1,48 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { AuthService } from '../services/auth.service';
+
+function getLoginRouteByRole(tipoRequerido: string): string {
+  switch (tipoRequerido.toUpperCase()) {
+    case 'FUNCIONARIO':
+      return '/acceso-funcionario';
+    case 'TTAIP':
+      return '/acceso-ttaip';
+    case 'ADMINISTRADOR':
+      return '/acceso-admin';
+    default:
+      return '/login';
+  }
+}
+
+export const authGuard: CanActivateFn = () => {
+  const authService = inject(AuthService);
+  const router = inject(Router);
+
+  if (authService.estaLogueado()) {
+    return true;
+  }
+
+  void router.navigate(['/login']);
+  return false;
+};
+
+export const tipoUsuarioGuard = (tipoRequerido: string): CanActivateFn => {
+  return () => {
+    const authService = inject(AuthService);
+    const router = inject(Router);
+
+    if (!authService.estaLogueado()) {
+      void router.navigate([getLoginRouteByRole(tipoRequerido)]);
+      return false;
+    }
+
+    const tipoUsuario = authService.getTipoUsuario();
+    if (tipoUsuario?.toLowerCase() === tipoRequerido.toLowerCase()) {
+      return true;
+    }
+
+    void router.navigate(['/']);
+    return false;
+  };
+};

--- a/transparencia-frontend/src/app/interceptors/auth.interceptor.ts
+++ b/transparencia-frontend/src/app/interceptors/auth.interceptor.ts
@@ -1,0 +1,34 @@
+import { isPlatformBrowser } from '@angular/common';
+import { HttpInterceptorFn } from '@angular/common/http';
+import { inject, PLATFORM_ID } from '@angular/core';
+
+export const authInterceptor: HttpInterceptorFn = (req, next) => {
+  const platformId = inject(PLATFORM_ID);
+
+  if (!isPlatformBrowser(platformId) || typeof localStorage === 'undefined') {
+    return next(req);
+  }
+
+  const usuarioData = localStorage.getItem('usuario');
+  if (!usuarioData) {
+    return next(req);
+  }
+
+  try {
+    const usuario = JSON.parse(usuarioData) as { token?: string };
+
+    if (!usuario.token) {
+      return next(req);
+    }
+
+    return next(
+      req.clone({
+        setHeaders: {
+          Authorization: `Bearer ${usuario.token}`
+        }
+      })
+    );
+  } catch {
+    return next(req);
+  }
+};


### PR DESCRIPTION
## Contexto
Implementación del sub-issue FE-03 de HU-01 para proteger rutas por rol y adjuntar token JWT automáticamente en requests HTTP.

## Cambios incluidos
* Agregar authGuard y tipoUsuarioGuard con validación case-insensitive y redirección por rol.
* Proteger rutas de ciudadano, funcionario y TTAIP con canActivate.
* Agregar authInterceptor para incluir Authorization Bearer cuando exista token.
* Registrar interceptor en app.config con withInterceptors([authInterceptor]).

## Trazabilidad de sub-issues
* Closes HU-01 · FE-03 · Implementar guards e interceptor #17
* ID commit: 49079a4
* ID commit: 2d12426
* Closes #17

## Validación
* Frontend build: npm run build -> OK
* Frontend tests: npm test -- --watch=false -> OK

## Riesgos y mitigaciones
* Riesgo: nuevas rutas internas podrían quedar sin guard.
* Mitigación: estandarizar canActivate con tipoUsuarioGuard en cada ruta protegida nueva.

## Checklist de revisión
- [ ] Validar redirecciones por rol en no autenticados
- [ ] Validar restricción por rol con comparación case-insensitive
- [ ] Validar header Authorization desde interceptor
- [ ] Tests y build en verde