### PR TITLE
🔀 test(HU-01): FE-04 · Pruebas unitarias auth frontend

### DIFF
--- a/transparencia-frontend/src/app/guards/auth.guard.spec.ts
+++ b/transparencia-frontend/src/app/guards/auth.guard.spec.ts
@@ -1,0 +1,86 @@
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { vi } from 'vitest';
+import { AuthService } from '../services/auth.service';
+import { authGuard, tipoUsuarioGuard } from './auth.guard';
+
+describe('authGuard', () => {
+  const authServiceMock = {
+    estaLogueado: vi.fn(),
+    getTipoUsuario: vi.fn(),
+  };
+  const routerMock = {
+    navigate: vi.fn().mockResolvedValue(true),
+  };
+
+  beforeEach(() => {
+    authServiceMock.estaLogueado.mockReset();
+    authServiceMock.getTipoUsuario.mockReset();
+    routerMock.navigate.mockReset();
+    routerMock.navigate.mockResolvedValue(true);
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: AuthService, useValue: authServiceMock },
+        { provide: Router, useValue: routerMock },
+      ],
+    });
+  });
+
+  function runAuthGuard() {
+    return TestBed.runInInjectionContext(() => authGuard({} as never, {} as never));
+  }
+
+  function runTipoUsuarioGuard(tipoRequerido: string) {
+    return TestBed.runInInjectionContext(() =>
+      tipoUsuarioGuard(tipoRequerido)({} as never, {} as never),
+    );
+  }
+
+  it('permite acceso cuando el usuario esta logueado', () => {
+    authServiceMock.estaLogueado.mockReturnValue(true);
+
+    const result = runAuthGuard();
+
+    expect(result).toBe(true);
+    expect(routerMock.navigate).not.toHaveBeenCalled();
+  });
+
+  it('deniega acceso cuando no esta logueado y redirige a /login', () => {
+    authServiceMock.estaLogueado.mockReturnValue(false);
+
+    const result = runAuthGuard();
+
+    expect(result).toBe(false);
+    expect(routerMock.navigate).toHaveBeenCalledWith(['/login']);
+  });
+
+  it('tipoUsuarioGuard permite acceso con comparacion case-insensitive', () => {
+    authServiceMock.estaLogueado.mockReturnValue(true);
+    authServiceMock.getTipoUsuario.mockReturnValue('funcionario');
+
+    const result = runTipoUsuarioGuard('FUNCIONARIO');
+
+    expect(result).toBe(true);
+    expect(routerMock.navigate).not.toHaveBeenCalled();
+  });
+
+  it('tipoUsuarioGuard deniega acceso por rol distinto y redirige a /', () => {
+    authServiceMock.estaLogueado.mockReturnValue(true);
+    authServiceMock.getTipoUsuario.mockReturnValue('CIUDADANO');
+
+    const result = runTipoUsuarioGuard('TTAIP');
+
+    expect(result).toBe(false);
+    expect(routerMock.navigate).toHaveBeenCalledWith(['/']);
+  });
+
+  it('tipoUsuarioGuard redirige al login correcto por rol cuando no esta logueado', () => {
+    authServiceMock.estaLogueado.mockReturnValue(false);
+
+    const result = runTipoUsuarioGuard('TTAIP');
+
+    expect(result).toBe(false);
+    expect(routerMock.navigate).toHaveBeenCalledWith(['/acceso-ttaip']);
+  });
+});

--- a/transparencia-frontend/src/app/interceptors/auth.interceptor.spec.ts
+++ b/transparencia-frontend/src/app/interceptors/auth.interceptor.spec.ts
@@ -1,0 +1,61 @@
+import { PLATFORM_ID } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { HttpRequest, HttpResponse } from '@angular/common/http';
+import { of } from 'rxjs';
+import { vi } from 'vitest';
+import { authInterceptor } from './auth.interceptor';
+
+describe('authInterceptor', () => {
+  afterEach(() => {
+    localStorage.removeItem('usuario');
+  });
+
+  function runInterceptor(platformId: string, request: HttpRequest<unknown>) {
+    TestBed.configureTestingModule({
+      providers: [{ provide: PLATFORM_ID, useValue: platformId }],
+    });
+
+    const next = vi.fn((req: HttpRequest<unknown>) =>
+      of(new HttpResponse({ status: 200, body: req.url })),
+    );
+
+    TestBed.runInInjectionContext(() => {
+      authInterceptor(request, next).subscribe();
+    });
+
+    return next;
+  }
+
+  it('agrega header Authorization cuando existe token en localStorage', () => {
+    localStorage.setItem('usuario', JSON.stringify({ token: 'jwt-token-test' }));
+    const request = new HttpRequest('GET', '/api/privado');
+
+    const next = runInterceptor('browser', request);
+    const forwarded = next.mock.calls[0]?.[0] as HttpRequest<unknown>;
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(forwarded.headers.get('Authorization')).toBe('Bearer jwt-token-test');
+  });
+
+  it('omite Authorization cuando no hay token en localStorage', () => {
+    localStorage.removeItem('usuario');
+    const request = new HttpRequest('GET', '/api/publico');
+
+    const next = runInterceptor('browser', request);
+    const forwarded = next.mock.calls[0]?.[0] as HttpRequest<unknown>;
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(forwarded.headers.has('Authorization')).toBe(false);
+  });
+
+  it('en SSR no agrega Authorization aunque exista localStorage', () => {
+    localStorage.setItem('usuario', JSON.stringify({ token: 'jwt-ssr' }));
+    const request = new HttpRequest('GET', '/api/ssr');
+
+    const next = runInterceptor('server', request);
+    const forwarded = next.mock.calls[0]?.[0] as HttpRequest<unknown>;
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(forwarded.headers.has('Authorization')).toBe(false);
+  });
+});

--- a/transparencia-frontend/src/app/services/auth.service.spec.ts
+++ b/transparencia-frontend/src/app/services/auth.service.spec.ts
@@ -1,0 +1,137 @@
+import { PLATFORM_ID } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { AuthService } from './auth.service';
+import {
+  LoginRequest,
+  LoginResponse,
+  RegistroRequest,
+  RegistroResponse,
+} from '../models/usuario.model';
+
+describe('AuthService', () => {
+  let service: AuthService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: PLATFORM_ID, useValue: 'browser' },
+      ],
+    });
+
+    service = TestBed.inject(AuthService);
+    httpMock = TestBed.inject(HttpTestingController);
+    localStorage.removeItem('usuario');
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+    localStorage.removeItem('usuario');
+  });
+
+  it('deberia crear el servicio', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('deberia hacer login con POST /api/auth/login', () => {
+    const payload: LoginRequest = {
+      identificador: '12345678',
+      password: 'Clave123',
+    };
+    const response: LoginResponse = {
+      success: true,
+      token: 'jwt-test-token',
+      tipoUsuario: 'CIUDADANO',
+      usuarioId: 1,
+      email: 'ciudadano@saip.gob.pe',
+    };
+
+    service.login(payload).subscribe((res) => {
+      expect(res).toEqual(response);
+    });
+
+    const req = httpMock.expectOne('/api/auth/login');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual(payload);
+    req.flush(response);
+  });
+
+  it('deberia registrar usuario con POST /api/auth/registro', () => {
+    const payload: RegistroRequest = {
+      email: 'nuevo@saip.gob.pe',
+      password: 'Clave123',
+      dni: '12345678',
+      nombreCompleto: 'Ciudadano Prueba',
+      telefono: '999999999',
+      direccion: 'Lima',
+    };
+    const response: RegistroResponse = {
+      success: true,
+      mensaje: 'Registro exitoso',
+      ciudadanoId: 10,
+      email: 'nuevo@saip.gob.pe',
+    };
+
+    service.registro(payload).subscribe((res) => {
+      expect(res).toEqual(response);
+    });
+
+    const req = httpMock.expectOne('/api/auth/registro');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual(payload);
+    req.flush(response);
+  });
+
+  it('deberia guardar y obtener sesion en localStorage', () => {
+    const sesion: LoginResponse = {
+      success: true,
+      token: 'jwt-session-token',
+      tipoUsuario: 'CIUDADANO',
+      usuarioId: 5,
+      email: 'usuario@saip.gob.pe',
+    };
+
+    service.guardarSesion(sesion);
+    const dataGuardada = localStorage.getItem('usuario');
+
+    expect(dataGuardada).not.toBeNull();
+    expect(service.obtenerSesion()).toEqual(sesion);
+  });
+
+  it('deberia exponer token y tipo de usuario desde la sesion', () => {
+    const sesion: LoginResponse = {
+      success: true,
+      token: 'jwt-token-123',
+      tipoUsuario: 'FUNCIONARIO',
+      usuarioId: 20,
+    };
+
+    service.guardarSesion(sesion);
+
+    expect(service.estaLogueado()).toBe(true);
+    expect(service.getToken()).toBe('jwt-token-123');
+    expect(service.getTipoUsuario()).toBe('FUNCIONARIO');
+  });
+
+  it('deberia limpiar sesion y retornar token/tipoUsuario nulos', () => {
+    service.guardarSesion({
+      success: true,
+      token: 'jwt-any',
+      tipoUsuario: 'ADMINISTRADOR',
+    });
+
+    service.cerrarSesion();
+
+    expect(localStorage.getItem('usuario')).toBeNull();
+    expect(service.estaLogueado()).toBe(false);
+    expect(service.getToken()).toBeNull();
+    expect(service.getTipoUsuario()).toBeNull();
+  });
+});


### PR DESCRIPTION
## Contexto
Implementación del sub-issue FE-04 de HU-01 para cubrir pruebas unitarias de autenticación en frontend.

## Cambios incluidos
* Agregar uth.service.spec.ts con pruebas de login, registro, sesión, token y tipoUsuario.
* Agregar uth.guard.spec.ts con acceso permitido/denegado y validación case-insensitive.
* Agregar uth.interceptor.spec.ts para añadir/omitir header Authorization y comportamiento SSR.
* Sincronizar rama con origin/develop antes de publicar el PR.

## Trazabilidad de sub-issues
* Closes HU-01 · FE-04 · Pruebas unitarias auth frontend #18
* ID commit: cdc8b05
* ID commit: bbeb686
* Closes #18

## Validación
* Frontend build: npm run build -> OK
* Frontend tests: npm test -- --watch=false -> OK

## Riesgos y mitigaciones
* Riesgo: cambios futuros en guards/interceptor podrían desalinear pruebas.
* Mitigación: mantener pruebas como contrato mínimo en CI para detectar regresiones.

## Checklist de revisión
- [ ] Validar cobertura de AuthService (login/registro/sesión/token/tipoUsuario)
- [ ] Validar escenarios de authGuard y tipoUsuarioGuard (incluye case-insensitive)
- [ ] Validar escenarios del authInterceptor (browser/SSR)
- [ ] Tests y build en verde