### PR TITLE
🔀 feat(HU-05): BE-01 · Endpoints de calificación

### DIFF
--- a/transparencia-backend/src/main/java/com/transparencia/api/controller/TTAIPRestController.java
+++ b/transparencia-backend/src/main/java/com/transparencia/api/controller/TTAIPRestController.java
@@ -1,0 +1,97 @@
+package com.transparencia.api.controller;
+
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import com.transparencia.api.model.dto.ApelacionDTO;
+import com.transparencia.api.model.dto.CalificacionRequest;
+import com.transparencia.api.model.entity.Apelacion;
+import com.transparencia.api.service.TTAIPService;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@Validated
+@RequestMapping("/api/ttaip")
+public class TTAIPRestController {
+
+    private final TTAIPService ttaipService;
+
+    public TTAIPRestController(TTAIPService ttaipService) {
+        this.ttaipService = ttaipService;
+    }
+
+    @GetMapping("/estadisticas")
+    public ResponseEntity<Map<String, Object>> obtenerEstadisticas() {
+        return ResponseEntity.ok(ttaipService.obtenerEstadisticas());
+    }
+
+    @GetMapping("/pendientes")
+    public ResponseEntity<List<ApelacionDTO>> listarPendientes() {
+        return ResponseEntity.ok(ttaipService.listarPendientes());
+    }
+
+    @GetMapping("/en-calificacion")
+    public ResponseEntity<List<ApelacionDTO>> listarEnCalificacion() {
+        return ResponseEntity.ok(ttaipService.listarPorEstado(Apelacion.EstadoApelacion.EN_CALIFICACION_1));
+    }
+
+    @GetMapping("/subsanacion")
+    public ResponseEntity<List<ApelacionDTO>> listarSubsanacion() {
+        return ResponseEntity.ok(ttaipService.listarPorEstado(Apelacion.EstadoApelacion.EN_SUBSANACION));
+    }
+
+    @GetMapping("/segunda-calificacion")
+    public ResponseEntity<List<ApelacionDTO>> listarSegundaCalificacion() {
+        return ResponseEntity.ok(ttaipService.listarPorEstado(Apelacion.EstadoApelacion.EN_CALIFICACION_2));
+    }
+
+    @GetMapping("/en-resolucion")
+    public ResponseEntity<List<ApelacionDTO>> listarEnResolucion() {
+        return ResponseEntity.ok(ttaipService.listarPorEstado(Apelacion.EstadoApelacion.EN_RESOLUCION));
+    }
+
+    @GetMapping("/resueltas")
+    public ResponseEntity<List<ApelacionDTO>> listarResueltas() {
+        return ResponseEntity.ok(ttaipService.listarResueltas());
+    }
+
+    @PostMapping("/calificacion/{apelacionId}/admitir")
+    public ResponseEntity<ApelacionDTO> admitirApelacion(
+        @PathVariable Long apelacionId,
+        @Valid @RequestBody CalificacionRequest request
+    ) {
+        return ResponseEntity.ok(ttaipService.admitirApelacion(apelacionId, request));
+    }
+
+    @PostMapping("/calificacion/{apelacionId}/subsanar")
+    public ResponseEntity<ApelacionDTO> requerirSubsanacion(
+        @PathVariable Long apelacionId,
+        @Valid @RequestBody CalificacionRequest request
+    ) {
+        return ResponseEntity.ok(ttaipService.requerirSubsanacion(apelacionId, request));
+    }
+
+    @PostMapping("/calificacion/{apelacionId}/inadmitir")
+    public ResponseEntity<ApelacionDTO> inadmitirApelacion(
+        @PathVariable Long apelacionId,
+        @Valid @RequestBody CalificacionRequest request
+    ) {
+        return ResponseEntity.ok(ttaipService.inadmitirApelacion(apelacionId, request));
+    }
+
+    @PostMapping("/calificacion/{apelacionId}/no-presentado")
+    public ResponseEntity<ApelacionDTO> declararNoPresentado(
+        @PathVariable Long apelacionId,
+        @Valid @RequestBody CalificacionRequest request
+    ) {
+        return ResponseEntity.ok(ttaipService.declararTenerPorNoPresentado(apelacionId, request));
+    }
+}

--- a/transparencia-backend/src/main/java/com/transparencia/api/model/dto/ApelacionDTO.java
+++ b/transparencia-backend/src/main/java/com/transparencia/api/model/dto/ApelacionDTO.java
@@ -1,5 +1,6 @@
 package com.transparencia.api.model.dto;
 
+import com.transparencia.api.model.entity.Apelacion;
 import java.time.LocalDateTime;
 import lombok.Data;
 
@@ -8,7 +9,35 @@ public class ApelacionDTO {
     private Long idApelacion;
     private String expediente;
     private String estado;
+    private String resultado;
     private LocalDateTime fechaApelacion;
+    private LocalDateTime fechaSubsanacion;
+    private Integer diasSubsanacion;
+    private Long ciudadanoId;
     private String ciudadanoNombre;
+    private Long solicitudId;
     private String solicitudExpediente;
+
+    public static ApelacionDTO from(Apelacion apelacion) {
+        ApelacionDTO dto = new ApelacionDTO();
+        dto.setIdApelacion(apelacion.getIdApelacion());
+        dto.setExpediente(apelacion.getExpediente());
+        dto.setEstado(apelacion.getEstado() != null ? apelacion.getEstado().name() : null);
+        dto.setResultado(apelacion.getResultado());
+        dto.setFechaApelacion(apelacion.getFechaApelacion());
+        dto.setFechaSubsanacion(apelacion.getFechaSubsanacion());
+        dto.setDiasSubsanacion(apelacion.getDiasSubsanacion());
+
+        if (apelacion.getCiudadano() != null) {
+            dto.setCiudadanoId(apelacion.getCiudadano().getIdUsuario());
+            dto.setCiudadanoNombre(apelacion.getCiudadano().getNombreCompleto());
+        }
+
+        if (apelacion.getSolicitud() != null) {
+            dto.setSolicitudId(apelacion.getSolicitud().getIdSolicitud());
+            dto.setSolicitudExpediente(apelacion.getSolicitud().getExpediente());
+        }
+
+        return dto;
+    }
 }

--- a/transparencia-backend/src/main/java/com/transparencia/api/model/dto/CalificacionRequest.java
+++ b/transparencia-backend/src/main/java/com/transparencia/api/model/dto/CalificacionRequest.java
@@ -1,0 +1,18 @@
+package com.transparencia.api.model.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CalificacionRequest(
+    @NotBlank(message = "Los fundamentos son obligatorios")
+    @Size(max = 5000, message = "Los fundamentos no pueden exceder 5000 caracteres")
+    String fundamentos,
+
+    Long miembroId,
+
+    @Size(max = 2000, message = "Las observaciones no pueden exceder 2000 caracteres")
+    String observaciones,
+
+    Integer diasSubsanacion
+) {
+}

--- a/transparencia-backend/src/main/java/com/transparencia/api/model/dto/ResolucionDTO.java
+++ b/transparencia-backend/src/main/java/com/transparencia/api/model/dto/ResolucionDTO.java
@@ -1,5 +1,6 @@
 package com.transparencia.api.model.dto;
 
+import com.transparencia.api.model.entity.Resolucion;
 import java.time.LocalDateTime;
 import lombok.Data;
 
@@ -9,6 +10,27 @@ public class ResolucionDTO {
     private String numeroResolucion;
     private String tipoResolucion;
     private String decision;
+    private String fundamentos;
+    private String observaciones;
     private LocalDateTime fechaResolucion;
+    private Long miembroId;
     private String miembroNombre;
+
+    public static ResolucionDTO from(Resolucion resolucion) {
+        ResolucionDTO dto = new ResolucionDTO();
+        dto.setIdResolucion(resolucion.getIdResolucion());
+        dto.setNumeroResolucion(resolucion.getNumeroResolucion());
+        dto.setTipoResolucion(resolucion.getTipoResolucion() != null ? resolucion.getTipoResolucion().name() : null);
+        dto.setDecision(resolucion.getDecision() != null ? resolucion.getDecision().name() : null);
+        dto.setFundamentos(resolucion.getFundamentos());
+        dto.setObservaciones(resolucion.getObservaciones());
+        dto.setFechaResolucion(resolucion.getFechaResolucion());
+
+        if (resolucion.getMiembroTTAIP() != null) {
+            dto.setMiembroId(resolucion.getMiembroTTAIP().getIdUsuario());
+            dto.setMiembroNombre(resolucion.getMiembroTTAIP().getNombreCompleto());
+        }
+
+        return dto;
+    }
 }

--- a/transparencia-backend/src/main/java/com/transparencia/api/repository/ApelacionRepository.java
+++ b/transparencia-backend/src/main/java/com/transparencia/api/repository/ApelacionRepository.java
@@ -1,0 +1,28 @@
+package com.transparencia.api.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import com.transparencia.api.model.entity.Apelacion;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface ApelacionRepository extends JpaRepository<Apelacion, Long> {
+
+    Optional<Apelacion> findByExpediente(String expediente);
+
+    List<Apelacion> findByCiudadano_IdUsuarioOrderByFechaApelacionDesc(Long ciudadanoId);
+
+    List<Apelacion> findByEstadoOrderByFechaApelacionDesc(Apelacion.EstadoApelacion estado);
+
+    long countByEstado(Apelacion.EstadoApelacion estado);
+
+    @Query("SELECT a FROM Apelacion a LEFT JOIN FETCH a.solicitud s LEFT JOIN FETCH s.entidad LEFT JOIN FETCH a.ciudadano WHERE a.idApelacion = :id")
+    Optional<Apelacion> findByIdWithDetails(@Param("id") Long id);
+
+    @Query("SELECT a FROM Apelacion a WHERE a.estado NOT IN :estadosFinales ORDER BY a.fechaApelacion DESC")
+    List<Apelacion> findPendientes(@Param("estadosFinales") List<Apelacion.EstadoApelacion> estadosFinales);
+}

--- a/transparencia-backend/src/main/java/com/transparencia/api/repository/ResolucionRepository.java
+++ b/transparencia-backend/src/main/java/com/transparencia/api/repository/ResolucionRepository.java
@@ -1,0 +1,17 @@
+package com.transparencia.api.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import com.transparencia.api.model.entity.Resolucion;
+
+import java.util.List;
+
+@Repository
+public interface ResolucionRepository extends JpaRepository<Resolucion, Long> {
+
+    List<Resolucion> findByApelacion_IdApelacion(Long apelacionId);
+
+    List<Resolucion> findByMiembroTTAIP_IdUsuario(Long miembroId);
+
+    List<Resolucion> findByTipoResolucion(Resolucion.TipoResolucion tipo);
+}

--- a/transparencia-backend/src/main/java/com/transparencia/api/service/ApelacionService.java
+++ b/transparencia-backend/src/main/java/com/transparencia/api/service/ApelacionService.java
@@ -1,0 +1,91 @@
+package com.transparencia.api.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import com.transparencia.api.model.entity.Apelacion;
+import com.transparencia.api.repository.ApelacionRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class ApelacionService {
+
+    private static final List<Apelacion.EstadoApelacion> ESTADOS_FINALES = List.of(
+        Apelacion.EstadoApelacion.RESUELTO,
+        Apelacion.EstadoApelacion.RESUELTO_FUNDADO,
+        Apelacion.EstadoApelacion.RESUELTO_FUNDADO_EN_PARTE,
+        Apelacion.EstadoApelacion.RESUELTO_INFUNDADO,
+        Apelacion.EstadoApelacion.RESUELTO_INFUNDADO_EN_PARTE,
+        Apelacion.EstadoApelacion.RESUELTO_IMPROCEDENTE,
+        Apelacion.EstadoApelacion.TENER_POR_NO_PRESENTADO,
+        Apelacion.EstadoApelacion.CONCLUSION_SUSTRACCION_MATERIA,
+        Apelacion.EstadoApelacion.CONCLUSION_DESISTIMIENTO
+    );
+
+    private final ApelacionRepository apelacionRepository;
+
+    public ApelacionService(ApelacionRepository apelacionRepository) {
+        this.apelacionRepository = apelacionRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public List<Apelacion> obtenerTodasLasApelaciones() {
+        return apelacionRepository.findAll();
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<Apelacion> obtenerApelacionPorId(Long id) {
+        return apelacionRepository.findById(id);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<Apelacion> obtenerApelacionPorExpediente(String expediente) {
+        return apelacionRepository.findByExpediente(expediente);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Apelacion> obtenerApelacionesPorEstado(Apelacion.EstadoApelacion estado) {
+        return apelacionRepository.findByEstadoOrderByFechaApelacionDesc(estado);
+    }
+
+    @Transactional(readOnly = true)
+    public long contarApelacionesPorEstado(Apelacion.EstadoApelacion estado) {
+        return apelacionRepository.countByEstado(estado);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Apelacion> findByCiudadanoId(Long ciudadanoId) {
+        return apelacionRepository.findByCiudadano_IdUsuarioOrderByFechaApelacionDesc(ciudadanoId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Apelacion> findPendientes() {
+        return apelacionRepository.findPendientes(ESTADOS_FINALES);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Apelacion> findAll() {
+        return apelacionRepository.findAll();
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<Apelacion> findById(Long id) {
+        return apelacionRepository.findById(id);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<Apelacion> findByIdWithDetails(Long id) {
+        return apelacionRepository.findByIdWithDetails(id);
+    }
+
+    @Transactional
+    public Apelacion save(Apelacion apelacion) {
+        return apelacionRepository.save(apelacion);
+    }
+
+    @Transactional(readOnly = true)
+    public long count() {
+        return apelacionRepository.count();
+    }
+}

--- a/transparencia-backend/src/main/java/com/transparencia/api/service/ResolucionService.java
+++ b/transparencia-backend/src/main/java/com/transparencia/api/service/ResolucionService.java
@@ -1,0 +1,54 @@
+package com.transparencia.api.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import com.transparencia.api.model.entity.Resolucion;
+import com.transparencia.api.repository.ResolucionRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class ResolucionService {
+
+    private final ResolucionRepository resolucionRepository;
+
+    public ResolucionService(ResolucionRepository resolucionRepository) {
+        this.resolucionRepository = resolucionRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public List<Resolucion> obtenerTodasLasResoluciones() {
+        return resolucionRepository.findAll();
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<Resolucion> obtenerResolucionPorId(Long id) {
+        return resolucionRepository.findById(id);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Resolucion> obtenerResolucionesPorApelacion(Long apelacionId) {
+        return resolucionRepository.findByApelacion_IdApelacion(apelacionId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Resolucion> obtenerResolucionesPorTipo(Resolucion.TipoResolucion tipo) {
+        return resolucionRepository.findByTipoResolucion(tipo);
+    }
+
+    @Transactional
+    public void guardarResolucion(Resolucion resolucion) {
+        resolucionRepository.save(resolucion);
+    }
+
+    @Transactional
+    public void save(Resolucion resolucion) {
+        resolucionRepository.save(resolucion);
+    }
+
+    @Transactional
+    public void eliminarResolucion(Long id) {
+        resolucionRepository.deleteById(id);
+    }
+}

--- a/transparencia-backend/src/main/java/com/transparencia/api/service/TTAIPService.java
+++ b/transparencia-backend/src/main/java/com/transparencia/api/service/TTAIPService.java
@@ -1,0 +1,240 @@
+package com.transparencia.api.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import com.transparencia.api.exception.RecursoNoEncontradoException;
+import com.transparencia.api.model.dto.ApelacionDTO;
+import com.transparencia.api.model.dto.CalificacionRequest;
+import com.transparencia.api.model.entity.Apelacion;
+import com.transparencia.api.model.entity.MiembroTTAIP;
+import com.transparencia.api.model.entity.Resolucion;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@Service
+public class TTAIPService {
+
+    private static final Set<Apelacion.EstadoApelacion> ESTADOS_RESUELTOS = Set.of(
+        Apelacion.EstadoApelacion.RESUELTO,
+        Apelacion.EstadoApelacion.RESUELTO_FUNDADO,
+        Apelacion.EstadoApelacion.RESUELTO_FUNDADO_EN_PARTE,
+        Apelacion.EstadoApelacion.RESUELTO_INFUNDADO,
+        Apelacion.EstadoApelacion.RESUELTO_INFUNDADO_EN_PARTE,
+        Apelacion.EstadoApelacion.RESUELTO_IMPROCEDENTE,
+        Apelacion.EstadoApelacion.TENER_POR_NO_PRESENTADO,
+        Apelacion.EstadoApelacion.CONCLUSION_SUSTRACCION_MATERIA,
+        Apelacion.EstadoApelacion.CONCLUSION_DESISTIMIENTO
+    );
+
+    private final ApelacionService apelacionService;
+    private final ResolucionService resolucionService;
+    private final MiembroTTAIPService miembroTTAIPService;
+
+    public TTAIPService(
+        ApelacionService apelacionService,
+        ResolucionService resolucionService,
+        MiembroTTAIPService miembroTTAIPService
+    ) {
+        this.apelacionService = apelacionService;
+        this.resolucionService = resolucionService;
+        this.miembroTTAIPService = miembroTTAIPService;
+    }
+
+    @Transactional(readOnly = true)
+    public Map<String, Object> obtenerEstadisticas() {
+        Map<String, Object> stats = new HashMap<>();
+        stats.put("total", apelacionService.count());
+
+        long pendientes =
+            apelacionService.contarApelacionesPorEstado(Apelacion.EstadoApelacion.PENDIENTE_ELEVACION)
+                + apelacionService.contarApelacionesPorEstado(Apelacion.EstadoApelacion.EN_CALIFICACION_1);
+        stats.put("pendientes", pendientes);
+
+        long enProceso =
+            apelacionService.contarApelacionesPorEstado(Apelacion.EstadoApelacion.EN_CALIFICACION_2)
+                + apelacionService.contarApelacionesPorEstado(Apelacion.EstadoApelacion.NOTIFICACION_SEGUNDA_CALIFICACION)
+                + apelacionService.contarApelacionesPorEstado(Apelacion.EstadoApelacion.EN_RESOLUCION);
+        stats.put("enProceso", enProceso);
+
+        stats.put("enSubsanacion", apelacionService.contarApelacionesPorEstado(Apelacion.EstadoApelacion.EN_SUBSANACION));
+
+        long resueltas =
+            apelacionService.contarApelacionesPorEstado(Apelacion.EstadoApelacion.RESUELTO)
+                + apelacionService.contarApelacionesPorEstado(Apelacion.EstadoApelacion.RESUELTO_FUNDADO)
+                + apelacionService.contarApelacionesPorEstado(Apelacion.EstadoApelacion.RESUELTO_FUNDADO_EN_PARTE)
+                + apelacionService.contarApelacionesPorEstado(Apelacion.EstadoApelacion.RESUELTO_INFUNDADO)
+                + apelacionService.contarApelacionesPorEstado(Apelacion.EstadoApelacion.RESUELTO_INFUNDADO_EN_PARTE)
+                + apelacionService.contarApelacionesPorEstado(Apelacion.EstadoApelacion.RESUELTO_IMPROCEDENTE)
+                + apelacionService.contarApelacionesPorEstado(Apelacion.EstadoApelacion.TENER_POR_NO_PRESENTADO)
+                + apelacionService.contarApelacionesPorEstado(Apelacion.EstadoApelacion.CONCLUSION_SUSTRACCION_MATERIA)
+                + apelacionService.contarApelacionesPorEstado(Apelacion.EstadoApelacion.CONCLUSION_DESISTIMIENTO);
+        stats.put("resueltas", resueltas);
+
+        return stats;
+    }
+
+    @Transactional(readOnly = true)
+    public List<ApelacionDTO> listarPendientes() {
+        return apelacionService.findPendientes().stream()
+            .map(ApelacionDTO::from)
+            .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<ApelacionDTO> listarPorEstado(Apelacion.EstadoApelacion estado) {
+        return apelacionService.obtenerApelacionesPorEstado(estado).stream()
+            .map(ApelacionDTO::from)
+            .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<ApelacionDTO> listarResueltas() {
+        return apelacionService.findAll().stream()
+            .filter(apelacion -> apelacion.getEstado() != null && ESTADOS_RESUELTOS.contains(apelacion.getEstado()))
+            .map(ApelacionDTO::from)
+            .toList();
+    }
+
+    @Transactional
+    public ApelacionDTO admitirApelacion(Long apelacionId, CalificacionRequest request) {
+        Apelacion apelacion = buscarApelacion(apelacionId);
+        boolean esSegundaCalificacion = apelacion.getEstado() == Apelacion.EstadoApelacion.EN_CALIFICACION_2;
+
+        Resolucion resolucion = crearResolucion(
+            apelacion,
+            esSegundaCalificacion
+                ? Resolucion.TipoResolucion.SEGUNDA_CALIFICACION
+                : Resolucion.TipoResolucion.PRIMERA_CALIFICACION,
+            esSegundaCalificacion
+                ? Resolucion.DecisionResolucion.ADMITIDO
+                : Resolucion.DecisionResolucion.ADMISIBLE,
+            request.fundamentos(),
+            request.miembroId()
+        );
+        resolucion.setObservaciones(request.observaciones());
+        resolucionService.save(resolucion);
+
+        if (esSegundaCalificacion) {
+            apelacion.setEstado(Apelacion.EstadoApelacion.NOTIFICACION_SEGUNDA_CALIFICACION);
+            apelacion.setCalificacionSegunda(Apelacion.Calificacion.ADMITIDO);
+        } else {
+            apelacion.setEstado(Apelacion.EstadoApelacion.EN_CALIFICACION_2);
+            apelacion.setCalificacionPrimera(Apelacion.Calificacion.ADMISIBLE);
+        }
+
+        apelacionService.save(apelacion);
+        return ApelacionDTO.from(apelacion);
+    }
+
+    @Transactional
+    public ApelacionDTO requerirSubsanacion(Long apelacionId, CalificacionRequest request) {
+        Apelacion apelacion = buscarApelacion(apelacionId);
+        int diasSubsanacion = request.diasSubsanacion() != null ? request.diasSubsanacion() : 2;
+
+        Resolucion resolucion = crearResolucion(
+            apelacion,
+            Resolucion.TipoResolucion.PRIMERA_CALIFICACION,
+            Resolucion.DecisionResolucion.INADMISIBLE,
+            request.fundamentos(),
+            request.miembroId()
+        );
+        resolucion.setObservaciones(request.observaciones());
+        resolucionService.save(resolucion);
+
+        apelacion.setEstado(Apelacion.EstadoApelacion.EN_SUBSANACION);
+        apelacion.setCalificacionPrimera(Apelacion.Calificacion.INADMISIBLE);
+        apelacion.setFechaSubsanacion(LocalDateTime.now());
+        apelacion.setDiasSubsanacion(diasSubsanacion);
+        apelacionService.save(apelacion);
+
+        return ApelacionDTO.from(apelacion);
+    }
+
+    @Transactional
+    public ApelacionDTO inadmitirApelacion(Long apelacionId, CalificacionRequest request) {
+        Apelacion apelacion = buscarApelacion(apelacionId);
+        boolean esSegundaCalificacion = apelacion.getEstado() == Apelacion.EstadoApelacion.EN_CALIFICACION_2;
+
+        Resolucion resolucion = crearResolucion(
+            apelacion,
+            esSegundaCalificacion
+                ? Resolucion.TipoResolucion.SEGUNDA_CALIFICACION
+                : Resolucion.TipoResolucion.PRIMERA_CALIFICACION,
+            Resolucion.DecisionResolucion.IMPROCEDENTE,
+            request.fundamentos(),
+            request.miembroId()
+        );
+        resolucion.setObservaciones(request.observaciones());
+        resolucionService.save(resolucion);
+
+        apelacion.setEstado(Apelacion.EstadoApelacion.RESUELTO_IMPROCEDENTE);
+        if (esSegundaCalificacion) {
+            apelacion.setCalificacionSegunda(Apelacion.Calificacion.IMPROCEDENTE);
+        } else {
+            apelacion.setCalificacionPrimera(Apelacion.Calificacion.IMPROCEDENTE);
+        }
+
+        apelacionService.save(apelacion);
+        return ApelacionDTO.from(apelacion);
+    }
+
+    @Transactional
+    public ApelacionDTO declararTenerPorNoPresentado(Long apelacionId, CalificacionRequest request) {
+        Apelacion apelacion = buscarApelacion(apelacionId);
+
+        Resolucion resolucion = crearResolucion(
+            apelacion,
+            Resolucion.TipoResolucion.PRIMERA_CALIFICACION,
+            Resolucion.DecisionResolucion.TENER_POR_NO_PRESENTADO,
+            request.fundamentos(),
+            request.miembroId()
+        );
+        resolucion.setObservaciones(request.observaciones());
+        resolucionService.save(resolucion);
+
+        apelacion.setEstado(Apelacion.EstadoApelacion.TENER_POR_NO_PRESENTADO);
+        apelacion.setResultado("TENER_POR_NO_PRESENTADO");
+        apelacionService.save(apelacion);
+
+        return ApelacionDTO.from(apelacion);
+    }
+
+    private Apelacion buscarApelacion(Long apelacionId) {
+        return apelacionService.findById(apelacionId)
+            .orElseThrow(() -> new RecursoNoEncontradoException("Apelacion no encontrada con ID: " + apelacionId));
+    }
+
+    private Resolucion crearResolucion(
+        Apelacion apelacion,
+        Resolucion.TipoResolucion tipo,
+        Resolucion.DecisionResolucion decision,
+        String fundamentos,
+        Long miembroId
+    ) {
+        Resolucion resolucion = new Resolucion();
+        resolucion.setApelacion(apelacion);
+        resolucion.setTipoResolucion(tipo);
+        resolucion.setDecision(decision);
+        resolucion.setFundamentos(fundamentos);
+        resolucion.setFechaResolucion(LocalDateTime.now());
+        asignarMiembro(resolucion, miembroId);
+        return resolucion;
+    }
+
+    private void asignarMiembro(Resolucion resolucion, Long miembroId) {
+        if (miembroId != null) {
+            miembroTTAIPService.obtenerMiembroTTAIPPorId(miembroId)
+                .ifPresent(resolucion::setMiembroTTAIP);
+            return;
+        }
+
+        List<MiembroTTAIP> miembros = miembroTTAIPService.obtenerMiembrosTTAIPActivos();
+        if (!miembros.isEmpty()) {
+            resolucion.setMiembroTTAIP(miembros.get(0));
+        }
+    }
+}

--- a/transparencia-backend/src/test/java/com/transparencia/api/security/SecurityConfigAuthorizationTest.java
+++ b/transparencia-backend/src/test/java/com/transparencia/api/security/SecurityConfigAuthorizationTest.java
@@ -66,6 +66,6 @@ class SecurityConfigAuthorizationTest {
     void rutaTtaip_conRolPermitido_debePasarSeguridad() throws Exception {
         mockMvc.perform(get("/api/ttaip/estadisticas")
             .with(user("miembro@saip.gob.pe").roles("TTAIP")))
-            .andExpect(status().isNotFound());
+            .andExpect(status().isOk());
     }
 }


### PR DESCRIPTION
## Contexto
Implementaci├│n del sub-issue HU-05 ┬À BE-01 para habilitar endpoints y l├│gica de primera calificaci├│n del TTAIP.

## Cambios incluidos
* Agregar TTAIPService con estad├¡sticas, listados y flujos admitir/subsanar/inadmitir/no-presentado.
* Agregar TTAIPRestController con endpoints /api/ttaip de consulta y calificaci├│n.
* Agregar CalificacionRequest, ApelacionService, ResolucionService, ApelacionRepository y ResolucionRepository.
* Ajustar mapeos de ApelacionDTO y ResolucionDTO para respuesta de calificaci├│n.
* Ajustar prueba de seguridad para la ruta TTAIP existente.

## Trazabilidad de sub-issues
* Closes HU-05 ┬À BE-01 ┬À Endpoints de calificaci├│n #44
* ID commit: ce67ad9
* ID commit: e036408
* Closes #44

## Validaci├│n
* Backend build: ./mvnw -DskipTests package -> OK
* Backend: ./mvnw test -> OK

## Riesgos y mitigaciones
* Riesgo: cambios futuros en el flujo de estados pueden impactar reglas de calificaci├│n.
* Mitigaci├│n: mantener validaci├│n de transiciones en la capa TTAIPService y reforzar pruebas unitarias en BE-04.

## Checklist de revisi├│n
- [ ] Validar endpoints /api/ttaip y respuestas por estado
- [ ] Validar transiciones de estado en admitir/subsanar/inadmitir/no-presentado
- [ ] Validar asignaci├│n de miembro TTAIP por miembroId o primer activo
- [ ] Tests y build en verde
