### PR TITLE
🔀 feat(HU-05): BE-02 · Validar plazo de 7 dias habiles

### DIFF
--- a/transparencia-backend/src/main/java/com/transparencia/api/service/TTAIPService.java
+++ b/transparencia-backend/src/main/java/com/transparencia/api/service/TTAIPService.java
@@ -8,7 +8,9 @@ import com.transparencia.api.model.dto.CalificacionRequest;
 import com.transparencia.api.model.entity.Apelacion;
 import com.transparencia.api.model.entity.MiembroTTAIP;
 import com.transparencia.api.model.entity.Resolucion;
+import com.transparencia.api.util.DiasHabilesUtil;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
@@ -104,6 +106,10 @@ public class TTAIPService {
         Apelacion apelacion = buscarApelacion(apelacionId);
         boolean esSegundaCalificacion = apelacion.getEstado() == Apelacion.EstadoApelacion.EN_CALIFICACION_2;
 
+        if (!esSegundaCalificacion) {
+            validarPlazoPrimeraCalificacion(apelacion);
+        }
+
         Resolucion resolucion = crearResolucion(
             apelacion,
             esSegundaCalificacion
@@ -133,6 +139,8 @@ public class TTAIPService {
     @Transactional
     public ApelacionDTO requerirSubsanacion(Long apelacionId, CalificacionRequest request) {
         Apelacion apelacion = buscarApelacion(apelacionId);
+        validarPlazoPrimeraCalificacion(apelacion);
+
         int diasSubsanacion = request.diasSubsanacion() != null ? request.diasSubsanacion() : 2;
 
         Resolucion resolucion = crearResolucion(
@@ -158,6 +166,10 @@ public class TTAIPService {
     public ApelacionDTO inadmitirApelacion(Long apelacionId, CalificacionRequest request) {
         Apelacion apelacion = buscarApelacion(apelacionId);
         boolean esSegundaCalificacion = apelacion.getEstado() == Apelacion.EstadoApelacion.EN_CALIFICACION_2;
+
+        if (!esSegundaCalificacion) {
+            validarPlazoPrimeraCalificacion(apelacion);
+        }
 
         Resolucion resolucion = crearResolucion(
             apelacion,
@@ -206,6 +218,23 @@ public class TTAIPService {
     private Apelacion buscarApelacion(Long apelacionId) {
         return apelacionService.findById(apelacionId)
             .orElseThrow(() -> new RecursoNoEncontradoException("Apelacion no encontrada con ID: " + apelacionId));
+    }
+
+    private void validarPlazoPrimeraCalificacion(Apelacion apelacion) {
+        if (apelacion.getFechaApelacion() == null) {
+            throw new IllegalArgumentException("La apelacion no tiene fecha de apelacion registrada");
+        }
+
+        int diasHabilesTranscurridos = DiasHabilesUtil.contarDiasHabiles(
+            apelacion.getFechaApelacion().toLocalDate(),
+            LocalDate.now()
+        );
+
+        if (diasHabilesTranscurridos > 7) {
+            throw new IllegalArgumentException(
+                "El plazo de 7 dias habiles para la primera calificacion ha vencido"
+            );
+        }
     }
 
     private Resolucion crearResolucion(


### PR DESCRIPTION
## Contexto
Se implementa HU-05 BE-02 para validar el plazo maximo de 7 dias habiles en la primera calificacion de apelaciones, evitando decisiones fuera del marco temporal del backlog.

## Cambios incluidos
* Se agrega validacion de plazo con DiasHabilesUtil.contarDiasHabiles(fechaApelacion, hoy).
* Se aplica la validacion en admitirApelacion, requerirSubsanacion e inadmitirApelacion cuando corresponde a primera calificacion.
* Se centraliza la regla en el helper validarPlazoPrimeraCalificacion dentro de TTAIPService.

## Trazabilidad de sub-issues
* Closes HU-05 · BE-02 · Validar plazo de 7 dias habiles #45
* ID commit: 480a08e

## Validacion
* Backend: ./mvnw test -> OK (53 tests, 0 failures, 0 errors)
* Backend build: ./mvnw -DskipTests package -> OK

## Riesgos y mitigaciones
* Riesgo: conteo de dias habiles depende de feriados configurados.
* Mitigacion: se reutiliza DiasHabilesUtil centralizado y probado en DiasHabilesUtilTest.

## Checklist de revision
- [ ] Verificar que admitir/requerirSubsanacion/inadmitir bloquean cuando el plazo supera 7 dias habiles.
- [ ] Verificar que segunda calificacion no se vea afectada por esta regla.
- [ ] Tests y build en verde.
