### PR TITLE
🔀 feat(HU-05): BE-03 · Flujo de estados y Resolucion

### DIFF
--- a/transparencia-backend/src/main/java/com/transparencia/api/service/TTAIPService.java
+++ b/transparencia-backend/src/main/java/com/transparencia/api/service/TTAIPService.java
@@ -107,6 +107,7 @@ public class TTAIPService {
         boolean esSegundaCalificacion = apelacion.getEstado() == Apelacion.EstadoApelacion.EN_CALIFICACION_2;
 
         if (!esSegundaCalificacion) {
+            validarEstadoPrimeraCalificacion(apelacion);
             validarPlazoPrimeraCalificacion(apelacion);
         }
 
@@ -139,6 +140,7 @@ public class TTAIPService {
     @Transactional
     public ApelacionDTO requerirSubsanacion(Long apelacionId, CalificacionRequest request) {
         Apelacion apelacion = buscarApelacion(apelacionId);
+        validarEstadoPrimeraCalificacion(apelacion);
         validarPlazoPrimeraCalificacion(apelacion);
 
         int diasSubsanacion = request.diasSubsanacion() != null ? request.diasSubsanacion() : 2;
@@ -168,6 +170,7 @@ public class TTAIPService {
         boolean esSegundaCalificacion = apelacion.getEstado() == Apelacion.EstadoApelacion.EN_CALIFICACION_2;
 
         if (!esSegundaCalificacion) {
+            validarEstadoPrimeraCalificacion(apelacion);
             validarPlazoPrimeraCalificacion(apelacion);
         }
 
@@ -218,6 +221,14 @@ public class TTAIPService {
     private Apelacion buscarApelacion(Long apelacionId) {
         return apelacionService.findById(apelacionId)
             .orElseThrow(() -> new RecursoNoEncontradoException("Apelacion no encontrada con ID: " + apelacionId));
+    }
+
+    private void validarEstadoPrimeraCalificacion(Apelacion apelacion) {
+        if (apelacion.getEstado() != Apelacion.EstadoApelacion.EN_CALIFICACION_1) {
+            throw new IllegalArgumentException(
+                "La apelacion debe estar en EN_CALIFICACION_1 para la primera calificacion"
+            );
+        }
     }
 
     private void validarPlazoPrimeraCalificacion(Apelacion apelacion) {


### PR DESCRIPTION
## Contexto
Se implementa HU-05 BE-03 para reforzar el flujo de estados de primera calificacion de apelaciones, asegurando transiciones validas segun backlog.

## Cambios incluidos
* Se agrega validacion de estado EN_CALIFICACION_1 para primera calificacion.
* Se aplica la validacion en admitirApelacion, requerirSubsanacion e inadmitirApelacion cuando corresponde a primera calificacion.
* Se mantiene la logica de segunda calificacion sin alterar su flujo.

## Trazabilidad de sub-issues
* Closes HU-05 · BE-03 · Flujo de estados y Resolucion #46
* ID commit: 11b396a

## Validacion
* Backend: ./mvnw test -> OK (53 tests, 0 failures, 0 errors)
* Backend build: ./mvnw -DskipTests package -> OK

## Riesgos y mitigaciones
* Riesgo: bloqueo de operaciones si la apelacion no esta en estado esperado.
* Mitigacion: mensaje de error explicito y validacion centralizada en servicio.

## Checklist de revision
- [ ] Verificar que primera calificacion solo opere desde EN_CALIFICACION_1.
- [ ] Verificar transiciones a EN_SUBSANACION, EN_CALIFICACION_2 y RESUELTO_IMPROCEDENTE.
- [ ] Tests y build en verde.