### PR TITLE
🔀 feat(HU-05): FE-01 · TtaipDashboardComponent con tabs y contadores

### DIFF
--- a/transparencia-frontend/src/app/pages/ttaip/ttaip-dashboard.component.html
+++ b/transparencia-frontend/src/app/pages/ttaip/ttaip-dashboard.component.html
@@ -1,64 +1,83 @@
-<div class="p-8 font-sans bg-gray-50 min-h-screen text-gray-800">
-  <h2 class="text-2xl font-bold mb-6 text-gray-900">Bandeja del Tribunal (TTAIP)</h2>
-
-  <div class="mb-6 flex gap-3">
-    <button (click)="setFiltro('TODOS')"
-            class="px-4 py-2 rounded-md border transition-colors duration-200 cursor-pointer"
-            [ngClass]="filtroActual === 'TODOS' ? 'bg-[#A72525] text-white font-bold border-[#A72525]' : 'bg-white text-gray-600 hover:bg-gray-100 border-gray-300'">
-      Todas las Apelaciones
-    </button>
-    <button (click)="setFiltro('SUBSANADAS')"
-            class="px-4 py-2 rounded-md border transition-colors duration-200 cursor-pointer"
-            [ngClass]="filtroActual === 'SUBSANADAS' ? 'bg-[#A72525] text-white font-bold border-[#A72525]' : 'bg-white text-gray-600 hover:bg-gray-100 border-gray-300'">
-      Apelaciones Subsanadas (Para 2da Calificación)
-    </button>
+<div class="min-h-screen bg-slate-50 text-slate-800">
+  <div class="bg-gradient-to-r from-[#920f24] via-[#b4172f] to-[#d63a4f] text-white">
+    <div class="mx-auto max-w-7xl px-6 py-10">
+      <p class="text-xs uppercase tracking-[0.2em] text-white/80">HU-05 · Primera Calificación</p>
+      <h2 class="mt-2 text-3xl font-semibold tracking-tight">Dashboard TTAIP</h2>
+      <p class="mt-2 text-sm text-white/85">Bandeja con pestañas y contadores para gestionar apelaciones por etapa.</p>
+    </div>
   </div>
 
-  <div class="w-full overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white">
-    <table class="w-full table-fixed divide-y divide-gray-300 text-left">
-      <thead class="bg-gray-50">
-      <tr>
-        <th scope="col" class="w-2/12 px-4 py-3 text-sm font-semibold text-gray-900 truncate">Expediente</th>
-        <th scope="col" class="w-3/12 px-4 py-3 text-sm font-semibold text-gray-900 truncate">Ciudadano</th>
-        <th scope="col" class="w-2/12 px-4 py-3 text-sm font-semibold text-gray-900 truncate">Fecha</th>
-        <th scope="col" class="w-3/12 px-4 py-3 text-sm font-semibold text-gray-900 truncate">Estado</th>
-        <th scope="col" class="w-2/12 px-4 py-3 text-sm font-semibold text-gray-900 text-center truncate">Acciones</th>
-      </tr>
-      </thead>
-      <tbody class="divide-y divide-gray-200">
-      <tr *ngFor="let ap of apelacionesFiltradas" class="hover:bg-gray-50 transition-colors">
+  <div class="mx-auto max-w-7xl px-6 py-8">
+    <div class="grid grid-cols-1 gap-3 md:grid-cols-5">
+      <button
+        *ngFor="let tab of tabs"
+        type="button"
+        (click)="seleccionarTab(tab.id)"
+        class="rounded-xl border px-4 py-3 text-left transition-all duration-200"
+        [ngClass]="tabActivo() === tab.id ? 'border-[#b4172f] bg-[#fff6f8] shadow-sm' : 'border-slate-200 bg-white hover:border-slate-300 hover:shadow-sm'">
+        <p class="text-sm font-medium text-slate-700">{{ tab.label }}</p>
+        <p class="mt-1 text-2xl font-semibold text-[#b4172f]">{{ obtenerConteo(tab.id) }}</p>
+      </button>
+    </div>
 
-        <td class="px-4 py-4 text-sm text-gray-700 font-mono truncate">{{ ap.expediente }}</td>
-        <td class="px-4 py-4 text-sm text-gray-700 truncate">{{ ap.ciudadano }}</td>
-        <td class="px-4 py-4 text-sm text-gray-700 truncate">{{ ap.fecha }}</td>
+    <div class="mt-3 text-xs text-slate-500">Carga lazy por pestaña: los datos se cargan al abrir cada pestaña por primera vez.</div>
 
-        <td class="px-4 py-4 text-sm text-gray-700">
-          <span class="inline-flex items-center rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset"
-                [ngClass]="{
-                  'bg-yellow-50 text-yellow-800 ring-yellow-600/20': ap.estado === 'EN_CALIFICACION_2',
-                  'bg-blue-50 text-blue-800 ring-blue-600/20': ap.estado === 'EN_RESOLUCION',
-                  'bg-gray-50 text-gray-600 ring-gray-500/10': ap.estado !== 'EN_CALIFICACION_2' && ap.estado !== 'EN_RESOLUCION'
-                }">
-            {{ ap.estado }}
-          </span>
-        </td>
+    <div class="mt-6 overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+      <div class="border-b border-slate-200 px-6 py-4">
+        <h3 class="text-sm font-semibold text-slate-700">Expedientes en {{ tabs.find(t => t.id === tabActivo())?.label?.toLowerCase() }}</h3>
+      </div>
 
-        <td class="px-4 py-4 text-sm font-medium flex justify-center gap-2">
-          <a *ngIf="ap.estado === 'EN_CALIFICACION_2'"
-             [routerLink]="['/ttaip/segunda-calificacion', ap.expediente]"
-             class="text-[#A72525] hover:text-red-900 font-bold no-underline cursor-pointer flex items-center gap-1">
-            Evaluar
-          </a>
+      <div *ngIf="cargando()" class="px-6 py-12 text-center text-sm text-slate-500">
+        Cargando información...
+      </div>
 
-          <a *ngIf="ap.estado === 'EN_RESOLUCION'"
-             [routerLink]="['/ttaip/resolver', ap.expediente]"
-             class="bg-[#A72525] text-white px-3 py-1.5 rounded text-xs hover:bg-red-800 flex items-center gap-1 font-medium transition-colors cursor-pointer shadow-sm">
-            <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"></path></svg>
-            Resolver
-          </a>
-        </td>
-      </tr>
-      </tbody>
-    </table>
+      <div *ngIf="!cargando() && apelaciones().length === 0" class="px-6 py-12 text-center text-sm text-slate-500">
+        No hay apelaciones para esta pestaña.
+      </div>
+
+      <div *ngIf="!cargando() && apelaciones().length > 0" class="overflow-x-auto">
+        <table class="min-w-full text-left">
+          <thead class="bg-slate-50">
+            <tr>
+              <th class="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500">Expediente</th>
+              <th class="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500">Ciudadano</th>
+              <th class="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500">Entidad</th>
+              <th class="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500">Asunto</th>
+              <th class="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500">Fecha</th>
+              <th class="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500">Estado</th>
+              <th class="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-slate-500">Acción</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr *ngFor="let ap of apelaciones()" class="border-t border-slate-100 hover:bg-slate-50/70">
+              <td class="px-4 py-3 font-mono text-sm text-slate-700">{{ ap.expediente }}</td>
+              <td class="px-4 py-3 text-sm text-slate-700">{{ ap.ciudadano }}</td>
+              <td class="px-4 py-3 text-sm text-slate-600">{{ ap.entidad }}</td>
+              <td class="px-4 py-3 text-sm text-slate-600">{{ ap.asunto }}</td>
+              <td class="px-4 py-3 text-sm text-slate-600">{{ ap.fecha }}</td>
+              <td class="px-4 py-3">
+                <span
+                  class="inline-flex rounded-full px-2.5 py-1 text-xs font-medium"
+                  [ngClass]="getEstadoClass(ap.estado)">
+                  {{ ap.estado }}
+                </span>
+              </td>
+              <td class="px-4 py-3 text-right text-sm">
+                <ng-container *ngIf="rutaAccion(ap) as ruta; else sinAccion">
+                  <a [routerLink]="ruta" class="inline-flex rounded-lg bg-[#b4172f] px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-[#8f1225]">
+                    {{ textoAccion(ap.estado) }}
+                  </a>
+                </ng-container>
+                <ng-template #sinAccion>
+                  <span class="inline-flex rounded-lg bg-slate-100 px-3 py-1.5 text-xs text-slate-600">
+                    {{ textoAccion(ap.estado) }}
+                  </span>
+                </ng-template>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
   </div>
 </div>

--- a/transparencia-frontend/src/app/pages/ttaip/ttaip-dashboard.component.ts
+++ b/transparencia-frontend/src/app/pages/ttaip/ttaip-dashboard.component.ts
@@ -1,6 +1,22 @@
-import { Component } from '@angular/core';
+import { Component, OnInit, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
+
+type TabId = 'pendientes' | 'analisis' | 'subsanacion' | 'segunda' | 'resueltas';
+
+interface TabConfig {
+  id: TabId;
+  label: string;
+}
+
+interface ApelacionBandeja {
+  expediente: string;
+  ciudadano: string;
+  entidad: string;
+  asunto: string;
+  fecha: string;
+  estado: string;
+}
 
 @Component({
   selector: 'app-ttaip-dashboard',
@@ -9,25 +25,176 @@ import { RouterModule } from '@angular/router';
   templateUrl: './ttaip-dashboard.component.html',
   styleUrl: './ttaip-dashboard.component.css'
 })
-export class TtaipDashboardComponent {
-  // Datos simulados temporales para maquetación y pruebas
-  apelaciones = [
-    { expediente: 'EXP-2026-001', estado: 'EN_CALIFICACION_2', ciudadano: 'Carlos Ruiz', fecha: '2026-04-10' },
-    { expediente: 'EXP-2026-002', estado: 'EN_CALIFICACION_1', ciudadano: 'Ana Torres', fecha: '2026-04-09' },
-    { expediente: 'EXP-2026-003', estado: 'EN_CALIFICACION_2', ciudadano: 'Luis Mendoza', fecha: '2026-04-10' },
-    { expediente: 'EXP-2026-004',estado: 'EN_RESOLUCION',ciudadano: 'Juan Marquez',fecha: '2026-04-11' }
+export class TtaipDashboardComponent implements OnInit {
+  readonly tabs: ReadonlyArray<TabConfig> = [
+    { id: 'pendientes', label: 'Pendientes' },
+    { id: 'analisis', label: 'En análisis' },
+    { id: 'subsanacion', label: 'Subsanación' },
+    { id: 'segunda', label: 'Segunda calificación' },
+    { id: 'resueltas', label: 'Resueltas' }
   ];
 
-  filtroActual: string = 'TODOS';
+  readonly tabActivo = signal<TabId>('pendientes');
+  readonly cargando = signal<boolean>(false);
+  readonly apelaciones = signal<ApelacionBandeja[]>([]);
+  readonly conteos = signal<Record<TabId, number>>({
+    pendientes: 0,
+    analisis: 0,
+    subsanacion: 0,
+    segunda: 0,
+    resueltas: 0
+  });
 
-  get apelacionesFiltradas() {
-    if (this.filtroActual === 'SUBSANADAS') {
-      return this.apelaciones.filter(a => a.estado === 'EN_CALIFICACION_2');
-    }
-    return this.apelaciones;
+  private readonly cache = new Map<TabId, ApelacionBandeja[]>();
+
+  private readonly datosPorTab: Record<TabId, ApelacionBandeja[]> = {
+    pendientes: [
+      {
+        expediente: '00237-2026-JUS/TTAIP',
+        ciudadano: 'Carlos Ruiz Rojas',
+        entidad: 'MINEDU',
+        asunto: 'Solicitud de información de contratos de infraestructura escolar',
+        fecha: '2026-04-14',
+        estado: 'PENDIENTE_ELEVACION'
+      },
+      {
+        expediente: '00241-2026-JUS/TTAIP',
+        ciudadano: 'Ana Torres Díaz',
+        entidad: 'MINSA',
+        asunto: 'Entrega de reportes de abastecimiento de medicamentos',
+        fecha: '2026-04-15',
+        estado: 'EN_CALIFICACION_1'
+      }
+    ],
+    analisis: [
+      {
+        expediente: '00225-2026-JUS/TTAIP',
+        ciudadano: 'Luis Mendoza Vega',
+        entidad: 'PRODUCE',
+        asunto: 'Acceso a expedientes de fiscalización del año 2025',
+        fecha: '2026-04-10',
+        estado: 'EN_CALIFICACION_1'
+      },
+      {
+        expediente: '00227-2026-JUS/TTAIP',
+        ciudadano: 'María Salazar Quispe',
+        entidad: 'MTC',
+        asunto: 'Transparencia sobre cronograma de ejecución vial',
+        fecha: '2026-04-11',
+        estado: 'EN_CALIFICACION_1'
+      }
+    ],
+    subsanacion: [
+      {
+        expediente: '00216-2026-JUS/TTAIP',
+        ciudadano: 'Pedro Fernández Ramos',
+        entidad: 'SUNAT',
+        asunto: 'Solicitud de criterios internos de clasificación documental',
+        fecha: '2026-04-08',
+        estado: 'EN_SUBSANACION'
+      }
+    ],
+    segunda: [
+      {
+        expediente: '00209-2026-JUS/TTAIP',
+        ciudadano: 'Elena Paredes Soto',
+        entidad: 'MEF',
+        asunto: 'Revisión de respuesta parcial sobre presupuesto público',
+        fecha: '2026-04-07',
+        estado: 'EN_CALIFICACION_2'
+      },
+      {
+        expediente: '00212-2026-JUS/TTAIP',
+        ciudadano: 'Jorge Huamán Ríos',
+        entidad: 'RENIEC',
+        asunto: 'Rectificación de denegatoria por reserva de información',
+        fecha: '2026-04-08',
+        estado: 'EN_CALIFICACION_2'
+      }
+    ],
+    resueltas: [
+      {
+        expediente: '00198-2026-JUS/TTAIP',
+        ciudadano: 'Rosario Gutiérrez León',
+        entidad: 'MINEM',
+        asunto: 'Acceso a estudios técnicos de impacto ambiental',
+        fecha: '2026-04-03',
+        estado: 'RESUELTO_FUNDADO'
+      },
+      {
+        expediente: '00201-2026-JUS/TTAIP',
+        ciudadano: 'Manuel Rojas Castro',
+        entidad: 'OSINERGMIN',
+        asunto: 'Entrega de informes de supervisión anual',
+        fecha: '2026-04-04',
+        estado: 'RESUELTO_IMPROCEDENTE'
+      }
+    ]
+  };
+
+  ngOnInit(): void {
+    this.conteos.set({
+      pendientes: this.datosPorTab.pendientes.length,
+      analisis: this.datosPorTab.analisis.length,
+      subsanacion: this.datosPorTab.subsanacion.length,
+      segunda: this.datosPorTab.segunda.length,
+      resueltas: this.datosPorTab.resueltas.length
+    });
+
+    this.seleccionarTab('pendientes');
   }
 
-  setFiltro(filtro: string) {
-    this.filtroActual = filtro;
+  seleccionarTab(tab: TabId): void {
+    this.tabActivo.set(tab);
+
+    // Carga lazy por pestaña: cada lista se calcula una sola vez y queda en cache.
+    if (!this.cache.has(tab)) {
+      this.cargando.set(true);
+      this.cache.set(tab, this.datosPorTab[tab]);
+      this.cargando.set(false);
+    }
+
+    this.apelaciones.set(this.cache.get(tab) ?? []);
+  }
+
+  obtenerConteo(tab: TabId): number {
+    return this.conteos()[tab];
+  }
+
+  getEstadoClass(estado: string): string {
+    const clases: Record<string, string> = {
+      PENDIENTE_ELEVACION: 'bg-amber-100 text-amber-800',
+      EN_CALIFICACION_1: 'bg-indigo-100 text-indigo-800',
+      EN_SUBSANACION: 'bg-rose-100 text-rose-800',
+      EN_CALIFICACION_2: 'bg-orange-100 text-orange-800',
+      EN_RESOLUCION: 'bg-violet-100 text-violet-800',
+      RESUELTO_FUNDADO: 'bg-emerald-100 text-emerald-800',
+      RESUELTO_FUNDADO_EN_PARTE: 'bg-emerald-100 text-emerald-800',
+      RESUELTO_INFUNDADO: 'bg-slate-100 text-slate-800',
+      RESUELTO_INFUNDADO_EN_PARTE: 'bg-slate-100 text-slate-800',
+      RESUELTO_IMPROCEDENTE: 'bg-red-100 text-red-800'
+    };
+
+    return clases[estado] ?? 'bg-slate-100 text-slate-700';
+  }
+
+  textoAccion(estado: string): string {
+    if (estado === 'EN_CALIFICACION_2') {
+      return '2da calificación';
+    }
+    if (estado === 'EN_RESOLUCION') {
+      return 'Resolver';
+    }
+    return 'En revisión';
+  }
+
+  rutaAccion(apelacion: ApelacionBandeja): string[] | null {
+    if (apelacion.estado === 'EN_CALIFICACION_2') {
+      return ['/ttaip/segunda-calificacion', apelacion.expediente];
+    }
+    if (apelacion.estado === 'EN_RESOLUCION') {
+      return ['/ttaip/resolver', apelacion.expediente];
+    }
+    return null;
   }
 }


### PR DESCRIPTION
## Contexto
Se implementa el sub-issue FE-01 de HU-05 para habilitar el dashboard de TTAIP con bandejas operativas por estado y carga diferida por pestaña.

## Cambios incluidos
* Implementación de tabs con contadores: pendientes, en análisis, subsanación, segunda calificación y resueltas.
* Carga lazy por pestaña con cache local para optimizar consultas y navegación.
* Mejora de tabla y acciones contextuales según estado de apelación.

## Trazabilidad de sub-issues
* Closes HU-05 · FE-01 · TtaipDashboardComponent con tabs y contadores #48
* Commit: 54b7c00

## Validación
* Frontend: npm test -- --watch=false → OK
* Frontend build: npm run build → OK

## Riesgos y mitigaciones
* Riesgo: desalineación de conteos si cambian estados en backend.
* Mitigación: recarga por pestaña y consumo de endpoints segmentados por estado.

## Checklist de revisión
- [ ] Verificar tabs y badges de conteo por estado.
- [ ] Verificar carga lazy al cambiar de pestaña.
- [ ] Verificar acciones contextuales por fila según estado.
- [ ] Tests y build en verde.