### PR TITLE
🔀 feat(HU-05): FE-02 · TtaipCalificarComponent con formulario base

### DIFF
--- a/transparencia-frontend/src/app/app.routes.ts
+++ b/transparencia-frontend/src/app/app.routes.ts
@@ -72,6 +72,11 @@ export const routes: Routes = [
     canActivate: [tipoUsuarioGuard('TTAIP')]
   },
   {
+    path: 'ttaip/calificar/:expediente',
+    loadComponent: () => import('./pages/ttaip/ttaip-calificar.component').then(m => m.TtaipCalificarComponent),
+    canActivate: [tipoUsuarioGuard('TTAIP')]
+  },
+  {
     path: 'ttaip/segunda-calificacion',
     loadComponent: () => import('./pages/ttaip/ttaip-segunda-calificacion.component').then(m => m.TtaipSegundaCalificacionComponent),
     canActivate: [tipoUsuarioGuard('TTAIP')]

--- a/transparencia-frontend/src/app/pages/ttaip/ttaip-calificar.component.css
+++ b/transparencia-frontend/src/app/pages/ttaip/ttaip-calificar.component.css
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/transparencia-frontend/src/app/pages/ttaip/ttaip-calificar.component.html
+++ b/transparencia-frontend/src/app/pages/ttaip/ttaip-calificar.component.html
@@ -1,0 +1,100 @@
+<div class="min-h-screen bg-slate-50 text-slate-800">
+  <div class="bg-gradient-to-r from-[#920f24] via-[#b4172f] to-[#d63a4f] text-white">
+    <div class="mx-auto max-w-6xl px-6 py-10">
+      <a routerLink="/ttaip" class="inline-flex items-center text-sm text-white/85 hover:text-white">
+        ← Volver al dashboard TTAIP
+      </a>
+      <p class="mt-3 text-xs uppercase tracking-[0.2em] text-white/80">HU-05 · FE-02</p>
+      <h2 class="mt-2 text-3xl font-semibold tracking-tight">Primera Calificacion</h2>
+      <p class="mt-2 text-sm text-white/85">Expediente: {{ expediente }}</p>
+    </div>
+  </div>
+
+  <div class="mx-auto max-w-6xl px-6 py-8">
+    <div class="grid gap-6 lg:grid-cols-2">
+      <section class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+        <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-500">Decision</h3>
+
+        <div class="mt-4 space-y-3">
+          <label class="flex cursor-pointer items-start gap-3 rounded-xl border border-slate-200 p-4 hover:border-slate-300">
+            <input type="radio" name="decision" [(ngModel)]="decision" value="admitir" class="mt-1">
+            <div>
+              <p class="text-sm font-semibold text-slate-700">Admitir</p>
+              <p class="text-xs text-slate-500">La apelacion continua a segunda calificacion.</p>
+            </div>
+          </label>
+
+          <label class="flex cursor-pointer items-start gap-3 rounded-xl border border-slate-200 p-4 hover:border-slate-300">
+            <input type="radio" name="decision" [(ngModel)]="decision" value="subsanar" class="mt-1">
+            <div>
+              <p class="text-sm font-semibold text-slate-700">Requerir subsanacion</p>
+              <p class="text-xs text-slate-500">Solicita subsanar observaciones en plazo definido.</p>
+            </div>
+          </label>
+
+          <label class="flex cursor-pointer items-start gap-3 rounded-xl border border-slate-200 p-4 hover:border-slate-300">
+            <input type="radio" name="decision" [(ngModel)]="decision" value="inadmitir" class="mt-1">
+            <div>
+              <p class="text-sm font-semibold text-slate-700">Inadmitir</p>
+              <p class="text-xs text-slate-500">La apelacion no cumple requisitos para continuar.</p>
+            </div>
+          </label>
+        </div>
+
+        <div *ngIf="esSubsanacion()" class="mt-5 rounded-xl border border-amber-200 bg-amber-50 p-4">
+          <h4 class="text-sm font-semibold text-amber-900">Datos de subsanacion</h4>
+
+          <label class="mt-3 block text-xs font-semibold uppercase tracking-wide text-amber-800">Observaciones</label>
+          <textarea
+            name="observaciones"
+            [(ngModel)]="observaciones"
+            rows="4"
+            class="mt-2 w-full rounded-xl border border-amber-200 bg-white px-3 py-2 text-sm text-slate-700 focus:border-amber-400 focus:outline-none"
+            placeholder="Detalle que debe corregir o completar el apelante."></textarea>
+
+          <label class="mt-3 block text-xs font-semibold uppercase tracking-wide text-amber-800">Dias de subsanacion</label>
+          <input
+            type="number"
+            min="1"
+            name="diasSubsanacion"
+            [(ngModel)]="diasSubsanacion"
+            class="mt-2 w-40 rounded-xl border border-amber-200 bg-white px-3 py-2 text-sm text-slate-700 focus:border-amber-400 focus:outline-none">
+        </div>
+      </section>
+
+      <section class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+        <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-500">Fundamentos</h3>
+
+        <label class="mt-4 block text-xs font-semibold uppercase tracking-wide text-slate-600">Fundamentos de la calificacion</label>
+        <textarea
+          name="fundamentos"
+          [(ngModel)]="fundamentos"
+          rows="10"
+          class="mt-2 w-full rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 focus:border-[#b4172f] focus:outline-none"
+          placeholder="Sustente la decision con criterios legales y tecnicos."></textarea>
+
+        <p class="mt-2 text-xs text-slate-500">{{ fundamentos.trim().length }} caracteres</p>
+
+        <div *ngIf="error()" class="mt-4 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {{ error() }}
+        </div>
+
+        <div *ngIf="mensaje()" class="mt-4 rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">
+          {{ mensaje() }}
+        </div>
+
+        <button
+          type="button"
+          (click)="registrarCalificacion()"
+          class="mt-5 inline-flex items-center rounded-xl bg-[#b4172f] px-5 py-2.5 text-sm font-medium text-white hover:bg-[#8f1225]">
+          Validar formulario
+        </button>
+      </section>
+    </div>
+
+    <section *ngIf="payloadPreview() as payload" class="mt-6 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+      <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-500">Vista previa de payload</h3>
+      <pre class="mt-3 overflow-x-auto rounded-xl bg-slate-900 p-4 text-xs text-slate-100">{{ payload | json }}</pre>
+    </section>
+  </div>
+</div>

--- a/transparencia-frontend/src/app/pages/ttaip/ttaip-calificar.component.ts
+++ b/transparencia-frontend/src/app/pages/ttaip/ttaip-calificar.component.ts
@@ -1,0 +1,87 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+
+type DecisionCalificacion = 'admitir' | 'subsanar' | 'inadmitir' | '';
+
+interface CalificacionPayload {
+  expediente: string;
+  decision: 'admitir' | 'subsanar' | 'inadmitir';
+  fundamentos: string;
+  observaciones?: string;
+  diasSubsanacion?: number;
+}
+
+@Component({
+  selector: 'app-ttaip-calificar',
+  standalone: true,
+  imports: [CommonModule, FormsModule, RouterLink],
+  templateUrl: './ttaip-calificar.component.html',
+  styleUrl: './ttaip-calificar.component.css'
+})
+export class TtaipCalificarComponent implements OnInit {
+  expediente = 'SIN-EXPEDIENTE';
+
+  decision: DecisionCalificacion = '';
+  fundamentos = '';
+  observaciones = '';
+  diasSubsanacion = 2;
+
+  readonly error = signal<string>('');
+  readonly mensaje = signal<string>('');
+  readonly payloadPreview = signal<CalificacionPayload | null>(null);
+
+  constructor(private readonly route: ActivatedRoute) {}
+
+  ngOnInit(): void {
+    this.expediente = this.route.snapshot.paramMap.get('expediente') ?? 'SIN-EXPEDIENTE';
+  }
+
+  esSubsanacion(): boolean {
+    return this.decision === 'subsanar';
+  }
+
+  registrarCalificacion(): void {
+    this.error.set('');
+    this.mensaje.set('');
+    this.payloadPreview.set(null);
+
+    const fundamentosLimpios = this.fundamentos.trim();
+    const observacionesLimpias = this.observaciones.trim();
+
+    if (!this.decision) {
+      this.error.set('Debe seleccionar una decision de calificacion.');
+      return;
+    }
+
+    if (!fundamentosLimpios) {
+      this.error.set('Los fundamentos son obligatorios.');
+      return;
+    }
+
+    if (this.decision === 'subsanar' && !observacionesLimpias) {
+      this.error.set('Las observaciones son obligatorias cuando se requiere subsanacion.');
+      return;
+    }
+
+    if (this.decision === 'subsanar' && this.diasSubsanacion < 1) {
+      this.error.set('El plazo de subsanacion debe ser mayor o igual a 1 dia habil.');
+      return;
+    }
+
+    const payload: CalificacionPayload = {
+      expediente: this.expediente,
+      decision: this.decision,
+      fundamentos: fundamentosLimpios
+    };
+
+    if (this.decision === 'subsanar') {
+      payload.observaciones = observacionesLimpias;
+      payload.diasSubsanacion = this.diasSubsanacion;
+    }
+
+    this.payloadPreview.set(payload);
+    this.mensaje.set('Formulario de primera calificacion validado. Listo para integracion en FE-03.');
+  }
+}

--- a/transparencia-frontend/src/app/pages/ttaip/ttaip-dashboard.component.ts
+++ b/transparencia-frontend/src/app/pages/ttaip/ttaip-dashboard.component.ts
@@ -179,6 +179,9 @@ export class TtaipDashboardComponent implements OnInit {
   }
 
   textoAccion(estado: string): string {
+    if (estado === 'PENDIENTE_ELEVACION' || estado === 'EN_CALIFICACION_1') {
+      return 'Calificar';
+    }
     if (estado === 'EN_CALIFICACION_2') {
       return '2da calificación';
     }
@@ -189,6 +192,9 @@ export class TtaipDashboardComponent implements OnInit {
   }
 
   rutaAccion(apelacion: ApelacionBandeja): string[] | null {
+    if (apelacion.estado === 'PENDIENTE_ELEVACION' || apelacion.estado === 'EN_CALIFICACION_1') {
+      return ['/ttaip/calificar', apelacion.expediente];
+    }
     if (apelacion.estado === 'EN_CALIFICACION_2') {
       return ['/ttaip/segunda-calificacion', apelacion.expediente];
     }


### PR DESCRIPTION
## Contexto
Se implementa el sub-issue FE-02 de HU-05 para habilitar el formulario de primera calificación TTAIP con decisiones de admisión, subsanación e inadmisión.

## Cambios incluidos
* Creación de TtaipCalificarComponent con formulario y validaciones de decisión/fundamentos.
* Campos condicionales para subsanación con observaciones obligatorias y días de subsanación (default 2).
* Registro de ruta protegida /ttaip/calificar/:expediente.
* Habilitación de acción Calificar desde el dashboard para estados de primera calificación.

## Trazabilidad de sub-issues
* Closes HU-05 · FE-02 · TtaipCalificarComponent con formulario base #49
* Commit: cc9da29

## Validación
* Frontend: npm test -- --watch=false → OK
* Frontend build: npm run build → OK

## Riesgos y mitigaciones
* Riesgo: inconsistencias de validación entre UI y backend.
* Mitigación: validaciones mínimas de formulario en cliente y envío tipado para integración FE-03.

## Checklist de revisión
- [ ] Verificar flujo de decisión (admitir/subsanar/inadmitir).
- [ ] Verificar obligatoriedad de observaciones al seleccionar subsanación.
- [ ] Verificar valor default de días de subsanación = 2.
- [ ] Verificar navegación por ruta /ttaip/calificar/:expediente.
- [ ] Tests y build en verde.