### PR TITLE
🔀 feat(HU-02): BE-06 · exponer API de entidades para SAIP

### DIFF
--- a/transparencia-backend/src/main/java/com/transparencia/api/controller/EntidadRestController.java
+++ b/transparencia-backend/src/main/java/com/transparencia/api/controller/EntidadRestController.java
@@ -1,0 +1,44 @@
+package com.transparencia.api.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+import com.transparencia.api.model.dto.EntidadDTO;
+import com.transparencia.api.model.entity.Entidad;
+import com.transparencia.api.service.EntidadService;
+
+import java.util.List;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+@RestController
+@RequestMapping("/api/entidades")
+public class EntidadRestController {
+
+    private final EntidadService entidadService;
+
+    public EntidadRestController(EntidadService entidadService) {
+        this.entidadService = entidadService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<EntidadDTO>> listar() {
+        List<EntidadDTO> entidades = entidadService.findActivas()
+            .stream()
+            .map(EntidadDTO::from)
+            .toList();
+
+        return ResponseEntity.ok(entidades);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<EntidadDTO> obtenerPorId(@PathVariable Long id) {
+        Entidad entidad = entidadService.findById(id)
+            .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "Entidad no encontrada con ID: " + id));
+
+        return ResponseEntity.ok(EntidadDTO.from(entidad));
+    }
+}

--- a/transparencia-backend/src/main/java/com/transparencia/api/model/dto/EntidadDTO.java
+++ b/transparencia-backend/src/main/java/com/transparencia/api/model/dto/EntidadDTO.java
@@ -1,0 +1,29 @@
+package com.transparencia.api.model.dto;
+
+import com.transparencia.api.model.entity.Entidad;
+
+public record EntidadDTO(
+    Long idEntidad,
+    String nombre,
+    String acronimo,
+    String descripcion,
+    String direccion,
+    String telefono,
+    String email,
+    String estado,
+    Boolean activa
+) {
+    public static EntidadDTO from(Entidad entidad) {
+        return new EntidadDTO(
+            entidad.getIdEntidad(),
+            entidad.getNombre(),
+            entidad.getAcronimo(),
+            entidad.getDescripcion(),
+            entidad.getDireccion(),
+            entidad.getTelefono(),
+            entidad.getEmail(),
+            entidad.getEstado(),
+            entidad.getActiva()
+        );
+    }
+}

--- a/transparencia-backend/src/main/java/com/transparencia/api/service/EntidadService.java
+++ b/transparencia-backend/src/main/java/com/transparencia/api/service/EntidadService.java
@@ -23,6 +23,11 @@ public class EntidadService {
     }
 
     @Transactional(readOnly = true)
+    public List<Entidad> findActivas() {
+        return entidadRepository.findByActivaTrue();
+    }
+
+    @Transactional(readOnly = true)
     public Optional<Entidad> findById(Long id) {
         return entidadRepository.findById(id);
     }


### PR DESCRIPTION
## Contexto
El flujo de Nueva SAIP en frontend requiere consultar entidades públicas para poblar el selector de entidad. En HU02 no existía el endpoint backend correspondiente, bloqueando la selección y el registro de solicitudes SAIP.

## Cambios incluidos
- Se agregó `EntidadRestController` con `GET /api/entidades` y `GET /api/entidades/{id}`.
- Se incorporó `EntidadDTO` para exponer datos de entidad sin acoplar el contrato a relaciones JPA.
- Se extendió `EntidadService` con `findActivas()` para listar únicamente entidades activas.

## Trazabilidad de sub-issues
- [x] `Closes #135` (sub-issue HU02 BE-06) en commit `2ce497c`.

## Validación
- Backend tests: `./mvnw.cmd test` -> **56/56 OK**.
- Backend build: `./mvnw.cmd -DskipTests package` -> **BUILD SUCCESS**.
- Rama sincronizada y publicada: `HU02-registrar-saip` en `origin`.

## Riesgos y mitigaciones
- Riesgo: cambios futuros en modelo de entidad podrían impactar contrato de salida.
- Mitigación: uso de DTO dedicado y servicio explícito para entidades activas.

## Checklist de revisión
- [ ] Endpoints de entidades responden correctamente para consumo de Nueva SAIP.
- [ ] Contrato backend es consistente con consumo frontend existente.
- [ ] No se exponen campos sensibles ni relaciones innecesarias.
- [ ] Validaciones del módulo backend en verde.