### PR TITLE
🔀 feat(HU-01): FE-05 · ajustar redirección y dashboards por rol

### DIFF
--- a/transparencia-frontend/src/app/app.routes.ts
+++ b/transparencia-frontend/src/app/app.routes.ts
@@ -33,8 +33,13 @@ export const routes: Routes = [
   },
   {
     path: 'ciudadano',
-    redirectTo: 'ciudadano/nueva-saip',
+    redirectTo: 'ciudadano/dashboard',
     pathMatch: 'full'
+  },
+  {
+    path: 'ciudadano/dashboard',
+    loadComponent: () => import('./pages/ciudadano/ciudadano-dashboard.component').then(m => m.CiudadanoDashboardComponent),
+    canActivate: [tipoUsuarioGuard('CIUDADANO')]
   },
   {
     path: 'ciudadano/nueva-saip',
@@ -53,6 +58,11 @@ export const routes: Routes = [
   },
   {
     path: 'funcionario',
+    redirectTo: 'funcionario/dashboard',
+    pathMatch: 'full'
+  },
+  {
+    path: 'funcionario/dashboard',
     loadComponent: () => import('./pages/funcionario/funcionario-dashboard.component').then(m => m.FuncionarioDashboardComponent),
     canActivate: [tipoUsuarioGuard('FUNCIONARIO')]
   },
@@ -68,6 +78,11 @@ export const routes: Routes = [
   },
   {
     path: 'ttaip',
+    redirectTo: 'ttaip/dashboard',
+    pathMatch: 'full'
+  },
+  {
+    path: 'ttaip/dashboard',
     loadComponent: () => import('./pages/ttaip/ttaip-dashboard.component').then(m => m.TtaipDashboardComponent),
     canActivate: [tipoUsuarioGuard('TTAIP')]
   },
@@ -93,7 +108,18 @@ export const routes: Routes = [
   },
   {
     path: 'ttaip/resolucion/:expediente',
-    loadComponent: () => import('./pages/ttaip/ttaip-resolucion-detalle.component').then(m => m.TtaipResolucionDetalleComponent)
+    loadComponent: () => import('./pages/ttaip/ttaip-resolucion-detalle.component').then(m => m.TtaipResolucionDetalleComponent),
+    canActivate: [tipoUsuarioGuard('TTAIP')]
+  },
+  {
+    path: 'admin',
+    redirectTo: 'admin/dashboard',
+    pathMatch: 'full'
+  },
+  {
+    path: 'admin/dashboard',
+    loadComponent: () => import('./pages/admin/admin-dashboard.component').then(m => m.AdminDashboardComponent),
+    canActivate: [tipoUsuarioGuard('ADMINISTRADOR')]
   },
   { path: '**', redirectTo: 'login' }
 ];

--- a/transparencia-frontend/src/app/pages/admin/admin-dashboard.component.css
+++ b/transparencia-frontend/src/app/pages/admin/admin-dashboard.component.css
@@ -1,0 +1,41 @@
+:host {
+  display: block;
+}
+
+.summary-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  border: 1px solid var(--ceniza-claro);
+  border-radius: 0.85rem;
+  background: var(--blanco);
+  padding: 1rem;
+  box-shadow: var(--shadow-sm);
+}
+
+.summary-label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--niebla);
+}
+
+.summary-value {
+  font-size: 1.6rem;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.metric-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--ceniza-claro);
+  padding-bottom: 0.5rem;
+}
+
+.metric-row:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}

--- a/transparencia-frontend/src/app/pages/admin/admin-dashboard.component.html
+++ b/transparencia-frontend/src/app/pages/admin/admin-dashboard.component.html
@@ -1,0 +1,120 @@
+<div class="min-h-screen bg-(--nieve-calida)">
+  <section class="bg-gradient-peru-hero px-4 pb-10 pt-24">
+    <div class="mx-auto max-w-7xl">
+      <div class="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 class="mt-2 text-3xl font-extrabold text-(--carbon)">Dashboard Administrador</h1>
+          <p class="mt-1 text-sm text-(--humo)">Vision general de solicitudes SAIP y apelaciones TTAIP.</p>
+        </div>
+        <button type="button" class="btn-outline h-10 px-4 text-sm" (click)="cerrarSesion()">
+          Cerrar sesion
+        </button>
+      </div>
+    </div>
+  </section>
+
+  <section class="mx-auto -mt-5 max-w-7xl px-4 pb-10">
+    @if (error()) {
+      <div class="alert-error mb-4">
+        <p>{{ error() }}</p>
+      </div>
+    }
+
+    @if (loading()) {
+      <div class="card py-16 text-center">
+        <div class="mx-auto h-10 w-10 animate-spin rounded-full border-4 border-(--ceniza) border-t-(--peru-rojo)"></div>
+        <p class="mt-4 text-sm text-(--niebla)">Cargando resumen administrativo...</p>
+      </div>
+    } @else {
+      <div class="grid grid-cols-2 gap-3 md:grid-cols-5">
+        <article class="summary-card">
+          <span class="summary-label">Solicitudes</span>
+          <span class="summary-value text-(--estado-azul)">{{ totalSolicitudes() }}</span>
+        </article>
+        <article class="summary-card">
+          <span class="summary-label">Respondidas</span>
+          <span class="summary-value text-(--estado-verde)">{{ respondidas() }}</span>
+        </article>
+        <article class="summary-card">
+          <span class="summary-label">Denegadas</span>
+          <span class="summary-value text-(--estado-rojo)">{{ denegadas() }}</span>
+        </article>
+        <article class="summary-card">
+          <span class="summary-label">Vencidas</span>
+          <span class="summary-value text-(--carbon)">{{ vencidas() }}</span>
+        </article>
+        <article class="summary-card">
+          <span class="summary-label">Atencion</span>
+          <span class="summary-value text-(--estado-ambar)">{{ tasaAtencion() }}%</span>
+        </article>
+      </div>
+
+      <div class="mt-5 grid grid-cols-1 gap-5 lg:grid-cols-2">
+        <article class="card overflow-hidden">
+          <header class="border-b border-(--ceniza-claro) px-5 py-4">
+            <h2 class="text-lg font-semibold text-(--carbon)">Estado de solicitudes SAIP</h2>
+          </header>
+          <div class="space-y-3 p-5 text-sm">
+            <div class="metric-row">
+              <span>Recepcionadas</span>
+              <strong>{{ recepcionadas() }}</strong>
+            </div>
+            <div class="metric-row">
+              <span>En revision</span>
+              <strong>{{ enRevision() }}</strong>
+            </div>
+            <div class="metric-row">
+              <span>Respondidas</span>
+              <strong>{{ respondidas() }}</strong>
+            </div>
+            <div class="metric-row">
+              <span>Denegadas</span>
+              <strong>{{ denegadas() }}</strong>
+            </div>
+            <div class="metric-row">
+              <span>Vencidas</span>
+              <strong>{{ vencidas() }}</strong>
+            </div>
+          </div>
+        </article>
+
+        <article class="card overflow-hidden">
+          <header class="border-b border-(--ceniza-claro) px-5 py-4">
+            <h2 class="text-lg font-semibold text-(--carbon)">Estado de apelaciones TTAIP</h2>
+          </header>
+          <div class="space-y-3 p-5 text-sm">
+            <div class="metric-row">
+              <span>Total apelaciones</span>
+              <strong>{{ totalApelaciones() }}</strong>
+            </div>
+            <div class="metric-row">
+              <span>Pendientes de admision</span>
+              <strong>{{ pendientesTtaip() }}</strong>
+            </div>
+            <div class="metric-row">
+              <span>En proceso</span>
+              <strong>{{ enProcesoTtaip() }}</strong>
+            </div>
+            <div class="metric-row">
+              <span>En subsanacion</span>
+              <strong>{{ enSubsanacionTtaip() }}</strong>
+            </div>
+            <div class="metric-row">
+              <span>Resueltas</span>
+              <strong>{{ resueltasTtaip() }}</strong>
+            </div>
+          </div>
+        </article>
+      </div>
+
+      <div class="mt-5 flex flex-wrap gap-3">
+        <a class="btn-outline h-10 px-4 text-sm" [routerLink]="['/funcionario/dashboard']" style="text-decoration: none;">
+          Ver panel funcionario
+        </a>
+        <a class="btn-outline h-10 px-4 text-sm" [routerLink]="['/ttaip/dashboard']" style="text-decoration: none;">
+          Ver panel TTAIP
+        </a>
+      </div>
+    }
+  </section>
+</div>

--- a/transparencia-frontend/src/app/pages/admin/admin-dashboard.component.ts
+++ b/transparencia-frontend/src/app/pages/admin/admin-dashboard.component.ts
@@ -1,0 +1,112 @@
+import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
+import { Router, RouterLink } from '@angular/router';
+import { forkJoin } from 'rxjs';
+import { AuthService } from '../../services/auth.service';
+import { SolicitudService } from '../../services/solicitud.service';
+import { TtaipService } from '../../services/ttaip.service';
+
+interface SolicitudEstadisticas {
+  total?: number;
+  recepcionadas?: number;
+  enRevision?: number;
+  pendienteInformacion?: number;
+  respondidas?: number;
+  denegadas?: number;
+  concluidas?: number;
+  vencidas?: number;
+}
+
+interface TtaipEstadisticas {
+  total?: number;
+  pendientesAdmision?: number;
+  pendientes?: number;
+  enProceso?: number;
+  enSubsanacion?: number;
+  resueltas?: number;
+}
+
+@Component({
+  selector: 'app-admin-dashboard',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [RouterLink],
+  templateUrl: './admin-dashboard.component.html',
+  styleUrl: './admin-dashboard.component.css',
+})
+export class AdminDashboardComponent {
+  private readonly authService = inject(AuthService);
+  private readonly router = inject(Router);
+  private readonly solicitudService = inject(SolicitudService);
+  private readonly ttaipService = inject(TtaipService);
+
+  readonly loading = signal(true);
+  readonly error = signal<string | null>(null);
+
+  readonly totalSolicitudes = signal(0);
+  readonly recepcionadas = signal(0);
+  readonly enRevision = signal(0);
+  readonly respondidas = signal(0);
+  readonly denegadas = signal(0);
+  readonly vencidas = signal(0);
+
+  readonly totalApelaciones = signal(0);
+  readonly pendientesTtaip = signal(0);
+  readonly enProcesoTtaip = signal(0);
+  readonly enSubsanacionTtaip = signal(0);
+  readonly resueltasTtaip = signal(0);
+
+  readonly tasaAtencion = computed(() => {
+    const total = this.totalSolicitudes();
+    if (total === 0) {
+      return 0;
+    }
+
+    const atendidas = this.respondidas() + this.denegadas();
+    return Math.round((atendidas / total) * 100);
+  });
+
+  constructor() {
+    this.cargarResumen();
+  }
+
+  cargarResumen(): void {
+    this.loading.set(true);
+    this.error.set(null);
+
+    forkJoin({
+      solicitudes: this.solicitudService.getEstadisticas(),
+      apelaciones: this.ttaipService.getEstadisticas(),
+    }).subscribe({
+      next: ({ solicitudes, apelaciones }) => {
+        this.aplicarEstadisticasSolicitudes(solicitudes as SolicitudEstadisticas);
+        this.aplicarEstadisticasTtaip(apelaciones as TtaipEstadisticas);
+        this.loading.set(false);
+      },
+      error: () => {
+        this.loading.set(false);
+        this.error.set('No se pudo cargar el resumen administrativo.');
+      },
+    });
+  }
+
+  cerrarSesion(): void {
+    this.authService.cerrarSesion();
+    void this.router.navigate(['/acceso-admin']);
+  }
+
+  private aplicarEstadisticasSolicitudes(data: SolicitudEstadisticas): void {
+    this.totalSolicitudes.set(data.total ?? 0);
+    this.recepcionadas.set(data.recepcionadas ?? 0);
+    this.enRevision.set((data.enRevision ?? 0) + (data.pendienteInformacion ?? 0));
+    this.respondidas.set((data.respondidas ?? 0) + (data.concluidas ?? 0));
+    this.denegadas.set(data.denegadas ?? 0);
+    this.vencidas.set(data.vencidas ?? 0);
+  }
+
+  private aplicarEstadisticasTtaip(data: TtaipEstadisticas): void {
+    this.totalApelaciones.set(data.total ?? 0);
+    this.pendientesTtaip.set(data.pendientesAdmision ?? data.pendientes ?? 0);
+    this.enProcesoTtaip.set(data.enProceso ?? 0);
+    this.enSubsanacionTtaip.set(data.enSubsanacion ?? 0);
+    this.resueltasTtaip.set(data.resueltas ?? 0);
+  }
+}

--- a/transparencia-frontend/src/app/pages/auth/login.component.ts
+++ b/transparencia-frontend/src/app/pages/auth/login.component.ts
@@ -43,7 +43,9 @@ export class LoginComponent implements OnInit {
       this.successMessage.set('Registro exitoso. Inicie sesión para continuar.');
     }
 
-    this.redirectIfSessionMatchesRoute();
+    if (this.accessMode() === 'internal') {
+      this.redirectIfSessionMatchesRoute();
+    }
   }
 
   get identificadorControl() {
@@ -194,10 +196,11 @@ export class LoginComponent implements OnInit {
 
   private resolveTargetRoute(response: LoginResponse, role: TipoUsuario | null): string {
     const backendRouteMap: Record<string, string> = {
-      '/ciudadano/dashboard': '/ciudadano',
-      '/entidad/dashboard': '/funcionario',
-      '/ttaip/dashboard': '/ttaip',
-      '/admin/dashboard': '/admin'
+      '/ciudadano/dashboard': '/ciudadano/dashboard',
+      '/entidad/dashboard': '/funcionario/dashboard',
+      '/funcionario/dashboard': '/funcionario/dashboard',
+      '/ttaip/dashboard': '/ttaip/dashboard',
+      '/admin/dashboard': '/admin/dashboard'
     };
 
     if (response.redirectUrl && backendRouteMap[response.redirectUrl]) {
@@ -205,10 +208,10 @@ export class LoginComponent implements OnInit {
     }
 
     const roleRouteMap: Record<TipoUsuario, string> = {
-      CIUDADANO: '/ciudadano',
-      FUNCIONARIO: '/funcionario',
-      TTAIP: '/ttaip',
-      ADMINISTRADOR: '/admin'
+      CIUDADANO: '/ciudadano/dashboard',
+      FUNCIONARIO: '/funcionario/dashboard',
+      TTAIP: '/ttaip/dashboard',
+      ADMINISTRADOR: '/admin/dashboard'
     };
 
     if (role) {
@@ -231,6 +234,8 @@ export class LoginComponent implements OnInit {
       case 'TTAIP':
       case 'ADMINISTRADOR':
         return normalized;
+      case 'ADMIN':
+        return 'ADMINISTRADOR';
       default:
         return null;
     }

--- a/transparencia-frontend/src/app/pages/ciudadano/ciudadano-dashboard.component.css
+++ b/transparencia-frontend/src/app/pages/ciudadano/ciudadano-dashboard.component.css
@@ -1,0 +1,28 @@
+:host {
+  display: block;
+}
+
+.summary-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  border: 1px solid var(--ceniza-claro);
+  border-radius: 0.85rem;
+  background: var(--blanco);
+  padding: 1rem;
+  box-shadow: var(--shadow-sm);
+}
+
+.summary-label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--niebla);
+}
+
+.summary-value {
+  font-size: 1.6rem;
+  font-weight: 800;
+  line-height: 1;
+}

--- a/transparencia-frontend/src/app/pages/ciudadano/ciudadano-dashboard.component.html
+++ b/transparencia-frontend/src/app/pages/ciudadano/ciudadano-dashboard.component.html
@@ -1,0 +1,108 @@
+<div class="min-h-screen bg-(--nieve-calida)">
+  <section class="bg-gradient-peru-hero px-4 pb-10 pt-24">
+    <div class="mx-auto max-w-7xl">
+      <div class="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 class="mt-2 text-3xl font-extrabold text-(--carbon)">Dashboard Ciudadano</h1>
+          <p class="mt-1 text-sm text-(--humo)">Bienvenido, {{ nombreUsuario() }}</p>
+        </div>
+        <button type="button" class="btn-outline h-10 px-4 text-sm" (click)="cerrarSesion()">
+          Cerrar sesion
+        </button>
+      </div>
+    </div>
+  </section>
+
+  <section class="mx-auto -mt-5 max-w-7xl px-4 pb-10">
+    <div class="mb-5 flex flex-wrap items-center gap-3">
+      <a class="btn-primary h-10 px-4 text-sm" [routerLink]="['/ciudadano/nueva-saip']" style="text-decoration: none;">
+        Nueva solicitud SAIP
+      </a>
+      <a class="btn-outline h-10 px-4 text-sm" [routerLink]="['/ciudadano/nueva-apelacion']" style="text-decoration: none;">
+        Presentar apelacion
+      </a>
+      <a class="btn-outline h-10 px-4 text-sm" [routerLink]="['/ciudadano/subsanacion']" style="text-decoration: none;">
+        Subsanacion
+      </a>
+    </div>
+
+    <div class="grid grid-cols-2 gap-3 md:grid-cols-4">
+      <article class="summary-card">
+        <span class="summary-label">Total</span>
+        <span class="summary-value text-(--estado-azul)">{{ total() }}</span>
+      </article>
+      <article class="summary-card">
+        <span class="summary-label">En Proceso</span>
+        <span class="summary-value text-(--estado-ambar)">{{ enProceso() }}</span>
+      </article>
+      <article class="summary-card">
+        <span class="summary-label">Atendidas</span>
+        <span class="summary-value text-(--estado-verde)">{{ atendidas() }}</span>
+      </article>
+      <article class="summary-card">
+        <span class="summary-label">Vencidas</span>
+        <span class="summary-value text-(--carbon)">{{ vencidas() }}</span>
+      </article>
+    </div>
+
+    @if (error()) {
+      <div class="alert-error mt-5">
+        <p>{{ error() }}</p>
+      </div>
+    }
+
+    <div class="card mt-5 overflow-hidden">
+      <div class="border-b border-(--ceniza-claro) px-5 py-4">
+        <h2 class="text-lg font-semibold text-(--carbon)">Mis solicitudes SAIP</h2>
+      </div>
+
+      @if (loading()) {
+        <div class="py-16 text-center">
+          <div class="mx-auto h-10 w-10 animate-spin rounded-full border-4 border-(--ceniza) border-t-(--peru-rojo)"></div>
+          <p class="mt-4 text-sm text-(--niebla)">Cargando solicitudes...</p>
+        </div>
+      } @else if (solicitudes().length === 0) {
+        <div class="py-16 text-center">
+          <p class="text-sm text-(--niebla)">Aun no tiene solicitudes registradas.</p>
+        </div>
+      } @else {
+        <div class="overflow-x-auto">
+          <table class="min-w-full border-collapse">
+            <thead class="bg-(--nieve) text-left">
+              <tr>
+                <th class="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-(--humo)">Expediente</th>
+                <th class="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-(--humo)">Asunto</th>
+                <th class="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-(--humo)">Fecha</th>
+                <th class="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-(--humo)">Estado</th>
+              </tr>
+            </thead>
+            <tbody>
+              @for (solicitud of solicitudes(); track solicitud.idSolicitud) {
+                <tr class="border-t border-(--ceniza-claro)">
+                  <td class="px-4 py-3">
+                    <span class="font-expediente text-sm text-(--carbon)">{{ solicitud.expediente }}</span>
+                  </td>
+                  <td class="max-w-90 px-4 py-3">
+                    <p class="truncate text-sm text-(--humo)" [title]="solicitud.asunto">{{ solicitud.asunto }}</p>
+                  </td>
+                  <td class="px-4 py-3 text-sm text-(--humo)">
+                    @if (solicitud.fechaPresentacion) {
+                      {{ solicitud.fechaPresentacion | date: 'dd/MM/yyyy' }}
+                    } @else {
+                      -
+                    }
+                  </td>
+                  <td class="px-4 py-3">
+                    <span class="inline-flex rounded-full px-2.5 py-1 text-xs font-semibold" [class]="getEstadoClass(solicitud.estado)">
+                      {{ solicitud.estado }}
+                    </span>
+                  </td>
+                </tr>
+              }
+            </tbody>
+          </table>
+        </div>
+      }
+    </div>
+  </section>
+</div>

--- a/transparencia-frontend/src/app/pages/ciudadano/ciudadano-dashboard.component.ts
+++ b/transparencia-frontend/src/app/pages/ciudadano/ciudadano-dashboard.component.ts
@@ -1,0 +1,129 @@
+import { ChangeDetectionStrategy, Component, PLATFORM_ID, computed, inject, signal } from '@angular/core';
+import { DatePipe, isPlatformBrowser } from '@angular/common';
+import { Router, RouterLink } from '@angular/router';
+import { Solicitud } from '../../models/solicitud.model';
+import { SolicitudService } from '../../services/solicitud.service';
+import { AuthService } from '../../services/auth.service';
+
+interface SesionCiudadano {
+  ciudadanoId?: number;
+  nombre?: string;
+}
+
+@Component({
+  selector: 'app-ciudadano-dashboard',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [DatePipe, RouterLink],
+  templateUrl: './ciudadano-dashboard.component.html',
+  styleUrl: './ciudadano-dashboard.component.css',
+})
+export class CiudadanoDashboardComponent {
+  private readonly authService = inject(AuthService);
+  private readonly router = inject(Router);
+  private readonly solicitudService = inject(SolicitudService);
+  private readonly platformId = inject(PLATFORM_ID);
+
+  readonly loading = signal(true);
+  readonly error = signal<string | null>(null);
+  readonly ciudadanoId = signal<number | null>(null);
+  readonly nombreUsuario = signal('Ciudadano');
+  readonly solicitudes = signal<Solicitud[]>([]);
+
+  readonly total = computed(() => this.solicitudes().length);
+
+  readonly enProceso = computed(() =>
+    this.solicitudes().filter((solicitud) =>
+      solicitud.estado === 'RECEPCIONADA'
+      || solicitud.estado === 'EN_REVISION'
+      || solicitud.estado === 'PENDIENTE_INFORMACION'
+    ).length,
+  );
+
+  readonly atendidas = computed(() =>
+    this.solicitudes().filter((solicitud) =>
+      solicitud.estado === 'RESPONDIDA'
+      || solicitud.estado === 'DENEGADA'
+      || solicitud.estado === 'CONCLUIDA'
+    ).length,
+  );
+
+  readonly vencidas = computed(() => this.solicitudes().filter((solicitud) => solicitud.estado === 'VENCIDA').length);
+
+  constructor() {
+    this.inicializarDesdeSesion();
+  }
+
+  cargarSolicitudes(): void {
+    const idCiudadano = this.ciudadanoId();
+
+    if (!idCiudadano) {
+      this.loading.set(false);
+      this.error.set('No se encontro un ciudadano asociado a la sesion.');
+      return;
+    }
+
+    this.loading.set(true);
+    this.error.set(null);
+
+    this.solicitudService.findByCiudadanoId(idCiudadano).subscribe({
+      next: (data) => {
+        this.solicitudes.set(data);
+        this.loading.set(false);
+      },
+      error: () => {
+        this.loading.set(false);
+        this.error.set('No se pudieron cargar sus solicitudes SAIP.');
+      },
+    });
+  }
+
+  getEstadoClass(estado: string): string {
+    const classes: Record<string, string> = {
+      RECEPCIONADA: 'bg-blue-100 text-blue-700 border border-blue-200',
+      EN_REVISION: 'bg-amber-100 text-amber-700 border border-amber-200',
+      PENDIENTE_INFORMACION: 'bg-amber-100 text-amber-700 border border-amber-200',
+      RESPONDIDA: 'bg-emerald-100 text-emerald-700 border border-emerald-200',
+      CONCLUIDA: 'bg-emerald-100 text-emerald-700 border border-emerald-200',
+      DENEGADA: 'bg-red-100 text-red-700 border border-red-200',
+      VENCIDA: 'bg-neutral-800 text-white border border-neutral-700',
+    };
+
+    return classes[estado] ?? 'bg-neutral-100 text-neutral-700 border border-neutral-200';
+  }
+
+  cerrarSesion(): void {
+    this.authService.cerrarSesion();
+    void this.router.navigate(['/login']);
+  }
+
+  private inicializarDesdeSesion(): void {
+    if (!isPlatformBrowser(this.platformId)) {
+      this.loading.set(false);
+      return;
+    }
+
+    const rawSesion = localStorage.getItem('usuario');
+    if (!rawSesion) {
+      this.loading.set(false);
+      this.error.set('No hay sesion activa de ciudadano.');
+      return;
+    }
+
+    try {
+      const sesion = JSON.parse(rawSesion) as SesionCiudadano;
+
+      if (typeof sesion.ciudadanoId !== 'number' || sesion.ciudadanoId <= 0) {
+        this.loading.set(false);
+        this.error.set('La sesion no contiene un ciudadano valido.');
+        return;
+      }
+
+      this.ciudadanoId.set(sesion.ciudadanoId);
+      this.nombreUsuario.set(sesion.nombre ?? 'Ciudadano');
+      this.cargarSolicitudes();
+    } catch {
+      this.loading.set(false);
+      this.error.set('No se pudo leer la sesion de usuario.');
+    }
+  }
+}

--- a/transparencia-frontend/src/app/services/auth.service.spec.ts
+++ b/transparencia-frontend/src/app/services/auth.service.spec.ts
@@ -16,6 +16,7 @@ import {
 describe('AuthService', () => {
   let service: AuthService;
   let httpMock: HttpTestingController;
+  const apiUrl = 'http://localhost:8080/api/auth';
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -40,7 +41,7 @@ describe('AuthService', () => {
     expect(service).toBeTruthy();
   });
 
-  it('deberia hacer login con POST /api/auth/login', () => {
+  it('deberia hacer login con POST backend /api/auth/login', () => {
     const payload: LoginRequest = {
       identificador: '12345678',
       password: 'Clave123',
@@ -57,13 +58,13 @@ describe('AuthService', () => {
       expect(res).toEqual(response);
     });
 
-    const req = httpMock.expectOne('/api/auth/login');
+    const req = httpMock.expectOne(`${apiUrl}/login`);
     expect(req.request.method).toBe('POST');
     expect(req.request.body).toEqual(payload);
     req.flush(response);
   });
 
-  it('deberia registrar usuario con POST /api/auth/registro', () => {
+  it('deberia registrar usuario con POST backend /api/auth/registro', () => {
     const payload: RegistroRequest = {
       email: 'nuevo@saip.gob.pe',
       password: 'Clave123',
@@ -83,7 +84,7 @@ describe('AuthService', () => {
       expect(res).toEqual(response);
     });
 
-    const req = httpMock.expectOne('/api/auth/registro');
+    const req = httpMock.expectOne(`${apiUrl}/registro`);
     expect(req.request.method).toBe('POST');
     expect(req.request.body).toEqual(payload);
     req.flush(response);

--- a/transparencia-frontend/src/app/services/auth.service.ts
+++ b/transparencia-frontend/src/app/services/auth.service.ts
@@ -11,7 +11,7 @@ export class AuthService {
   private readonly http = inject(HttpClient);
   private readonly platformId = inject(PLATFORM_ID);
   private readonly isBrowser = isPlatformBrowser(this.platformId);
-  private readonly apiUrl = '/api/auth';
+  private readonly apiUrl = 'http://localhost:8080/api/auth';
 
   login(credentials: LoginRequest): Observable<LoginResponse> {
     return this.http.post<LoginResponse>(`${this.apiUrl}/login`, credentials);


### PR DESCRIPTION
## Contexto
El acceso posterior al login presentaba redirecciones inconsistentes por tipo de usuario y faltaban dashboards base para algunos perfiles, afectando la navegación inicial del módulo frontend en HU01.

## Cambios incluidos
- Se ajustaron redirecciones de rutas base hacia dashboards explícitos por rol.
- Se incorporó la ruta de dashboard para ciudadano y admin.
- Se reforzó la resolución de ruta destino en login según `redirectUrl`/rol normalizado.
- Se normalizó `ADMIN` a `ADMINISTRADOR` para compatibilidad con guardias.
- Se agregaron componentes de dashboard base para ciudadano y admin.
- Se actualizaron `AuthService` y sus pruebas para consumo explícito del backend de autenticación.

## Trazabilidad de sub-issues
- [x] `Closes #133` en commit `4ebd8cc`.

## Validación
- Frontend tests: `npm test -- --watch=false` -> **67/67 OK**.
- Frontend build: `npm run build` -> **BUILD SUCCESS**.
- Delta contra `develop` antes del PR: `0 1` (solo un commit de alcance FE-05).

## Riesgos y mitigaciones
- Riesgo: cambios en rutas puedan impactar deep links existentes.
- Mitigación: rutas protegidas por rol y redirecciones explícitas a dashboards; cobertura de tests de auth y navegación preservada.

## Checklist de revisión
- [ ] Verificar redirección correcta tras login para cada rol.
- [ ] Verificar acceso a dashboards de ciudadano y admin con guardias.
- [ ] Verificar que auth.service mantiene contrato esperado con backend.
- [ ] Confirmar que no hay cambios fuera del alcance FE-05.