### PR TITLE
🔀 feat(HU-03): FE-05 · fortalecer dashboard y respuesta SAIP

### DIFF
--- a/transparencia-frontend/src/app/pages/funcionario/funcionario-dashboard.component.html
+++ b/transparencia-frontend/src/app/pages/funcionario/funcionario-dashboard.component.html
@@ -1,8 +1,15 @@
 <div class="min-h-screen bg-(--nieve-calida)">
   <section class="bg-gradient-peru-hero px-4 pb-10 pt-24">
     <div class="mx-auto max-w-7xl">
-      <h1 class="mt-2 text-3xl font-extrabold text-(--carbon)">Dashboard de Funcionario</h1>
-      <p class="mt-1 text-sm text-(--humo)">{{ entidadNombre() }}</p>
+      <div class="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 class="mt-2 text-3xl font-extrabold text-(--carbon)">Dashboard de Funcionario</h1>
+          <p class="mt-1 text-sm text-(--humo)">{{ entidadNombre() }}</p>
+        </div>
+        <button type="button" class="btn-outline h-10 px-4 text-sm" (click)="cerrarSesion()">
+          Cerrar sesion
+        </button>
+      </div>
     </div>
   </section>
 

--- a/transparencia-frontend/src/app/pages/funcionario/funcionario-dashboard.component.ts
+++ b/transparencia-frontend/src/app/pages/funcionario/funcionario-dashboard.component.ts
@@ -7,7 +7,7 @@ import {
   signal,
 } from '@angular/core';
 import { DatePipe, isPlatformBrowser } from '@angular/common';
-import { RouterLink } from '@angular/router';
+import { Router, RouterLink } from '@angular/router';
 import { Solicitud } from '../../models/solicitud.model';
 import { SolicitudService } from '../../services/solicitud.service';
 
@@ -24,6 +24,7 @@ interface SesionFuncionario {
   styleUrl: './funcionario-dashboard.component.css',
 })
 export class FuncionarioDashboardComponent {
+  private readonly router = inject(Router);
   private readonly solicitudService = inject(SolicitudService);
   private readonly platformId = inject(PLATFORM_ID);
 
@@ -116,6 +117,14 @@ export class FuncionarioDashboardComponent {
 
   obtenerDiasRestantes(solicitud: Solicitud): number | null {
     return typeof solicitud.diasRestantes === 'number' ? solicitud.diasRestantes : null;
+  }
+
+  cerrarSesion(): void {
+    if (isPlatformBrowser(this.platformId)) {
+      localStorage.removeItem('token');
+      localStorage.removeItem('usuario');
+    }
+    void this.router.navigate(['/acceso-funcionario']);
   }
 
   private inicializarDesdeSesion(): void {

--- a/transparencia-frontend/src/app/pages/funcionario/funcionario-responder.component.ts
+++ b/transparencia-frontend/src/app/pages/funcionario/funcionario-responder.component.ts
@@ -176,8 +176,8 @@ export class FuncionarioResponderComponent {
       funcionarioId,
       tipoRespuesta: 'DENEGACION_TOTAL',
       contenido,
-      causalDenegatoria: this.formulario.controls.causalDenegatoria.value?.trim() || null,
-      fundamentoLegal: this.formulario.controls.fundamentoLegal.value?.trim() || null,
+      causalDenegatoria: this.formulario.controls.causalDenegatoria.value?.trim() || undefined,
+      fundamentoLegal: this.formulario.controls.fundamentoLegal.value?.trim() || undefined,
     };
 
     this.respuestaService.denegarSolicitud(payload).subscribe({


### PR DESCRIPTION
## Contexto
El flujo del funcionario en HU03 requería ajustes de usabilidad en dashboard y consistencia en la generación de respuesta para solicitudes SAIP, especialmente en escenarios de denegación.

## Cambios incluidos
- Se añadió acción de cierre de sesión en el dashboard de funcionario.
- Se actualizó la cabecera del dashboard para incluir control de sesión sin afectar el listado operativo.
- Se ajustó la construcción del payload de denegación para manejar correctamente campos opcionales.
- Se mantuvo el flujo de respuesta compatible con el contrato de la rama HU03.

## Trazabilidad de sub-issues
- [x] `Closes #136` mediante commit `9500859`.

## Validación
- Frontend tests: `npm test -- --watch=false` -> **37/37 OK** (suite de la rama HU03).
- Frontend build: `npm run build` -> **BUILD SUCCESS**.
- Delta contra `develop` al abrir PR: `55 1` (1 commit nuevo en HU03 sobre su línea base).

## Riesgos y mitigaciones
- Riesgo: cambios en dashboard podrían alterar navegación de salida.
- Mitigación: redirección explícita al acceso de funcionario y limpieza de sesión local.
- Riesgo: variación en campos opcionales de denegación.
- Mitigación: envío controlado de opcionales para evitar payloads ambiguos.

## Checklist de revisión
- [ ] Verificar cierre de sesión desde dashboard de funcionario.
- [ ] Verificar respuesta de denegación con y sin campos opcionales.
- [ ] Verificar que la pantalla de respuesta mantiene flujo esperado de HU03.
- [ ] Confirmar build y tests en CI.