### PR TITLE
🔀 fix(HU-05): corregir valor inicial de expediente en calificación TTAIP

### DIFF
--- a/transparencia-frontend/src/app/pages/ttaip/ttaip-calificar.component.ts
+++ b/transparencia-frontend/src/app/pages/ttaip/ttaip-calificar.component.ts
@@ -16,7 +16,7 @@ type DecisionCalificacion = 'admitir' | 'subsanar' | 'inadmitir' | '';
   styleUrl: './ttaip-calificar.component.css'
 })
 export class TtaipCalificarComponent implements OnInit {
-  expediente = 'SIN-EXPEDIENTE';
+  expediente = '';
 
   decision: DecisionCalificacion = '';
   fundamentos = '';


### PR DESCRIPTION
## Contexto
En la pantalla de primera calificación TTAIP, el estado inicial mostraba `SIN-EXPEDIENTE` antes de cargar el valor real desde la ruta. Ese placeholder podía confundirse con un dato válido del expediente.

## Cambios incluidos
- Se ajusta el valor inicial de `expediente` a cadena vacía en `transparencia-frontend/src/app/pages/ttaip/ttaip-calificar.component.ts`.
- Se mantiene intacto el flujo de carga del expediente real por parámetro de ruta.

## Trazabilidad de sub-issues
- [x] Closes #142 mediante commit `af54e5d`.

## Validación
- Frontend: `npm test -- --watch=false` -> OK (66 tests).
- Frontend build: `npm run build` -> OK.

## Riesgos y mitigaciones
- Riesgo: bajo. El cambio afecta solo estado inicial visual del componente.
- Mitigación: pruebas y build en verde; no se altera lógica de negocio ni llamadas HTTP.

## Checklist de revisión
- [ ] Estado inicial del campo no induce interpretación errónea.
- [ ] Carga de expediente por ruta sigue funcionando.
- [ ] Validación frontend en verde verificada.