### PR TITLE
✨ feat(HU-07): BE-02 · Bifurcación admitir/rechazar segunda calificación

### DIFF
--- a/transparencia-backend/src/main/java/com/transparencia/api/service/ApelacionService.java
+++ b/transparencia-backend/src/main/java/com/transparencia/api/service/ApelacionService.java
@@ -127,18 +127,30 @@ public class ApelacionService {
 
         documentoRepository.save(documento);
 
-        // Flujo parametrizado según decisión
-        if ("ADMISIBLE".equalsIgnoreCase(request.getDecision())) {
-            // Pasa a Calificación Final
+        // Flujo parametrizado según decisión (HU-07 BE-02)
+        if ("ADMISIBLE".equalsIgnoreCase(request.getDecision()) || "ADMITIDO".equalsIgnoreCase(request.getDecision())) {
+            // Pasa a Calificación Final (En Resolución)
             apelacion.setEstado(Apelacion.EstadoApelacion.EN_RESOLUCION);
             apelacion.setResultado("ADMITIDO EN SEGUNDA CALIFICACIÓN");
+            apelacion.setCalificacionSegunda(Apelacion.Calificacion.ADMISIBLE);
+
+        } else if ("TENER_POR_NO_PRESENTADO".equalsIgnoreCase(request.getDecision()) || "NO_PRESENTADO".equalsIgnoreCase(request.getDecision())) {
+            // El ciudadano no subsanó a tiempo
+            apelacion.setEstado(Apelacion.EstadoApelacion.TENER_POR_NO_PRESENTADO);
+            apelacion.setResultado("TENER POR NO PRESENTADO POR FALTA DE SUBSANACIÓN");
+
         } else if ("IMPROCEDENTE".equalsIgnoreCase(request.getDecision())) {
             // Cierre definitivo como Improcedente
             apelacion.setEstado(Apelacion.EstadoApelacion.RESUELTO_IMPROCEDENTE);
-            apelacion.setResultado("IMPROCEDENTE");
+            apelacion.setResultado("RECHAZO DEFINITIVO - IMPROCEDENTE");
+            apelacion.setCalificacionSegunda(Apelacion.Calificacion.IMPROCEDENTE);
+
         } else {
-            throw new IllegalArgumentException("Decisión no válida. Solo se acepta ADMISIBLE o IMPROCEDENTE.");
+            throw new IllegalArgumentException("Decisión no válida. Solo se acepta ADMISIBLE, TENER_POR_NO_PRESENTADO o IMPROCEDENTE.");
         }
+
+        // Guardar los fundamentos sin importar qué decisión se tomó
+        apelacion.setFundamentos(request.getFundamentos());
 
         return apelacionRepository.save(apelacion);
     }


### PR DESCRIPTION
## Objetivo de la Historia de Usuario
Implementar la lógica del Backend para la **HU-07: Emitir Respuesta de Segunda Calificación**. Se integró el procesamiento de la decisión del TTAIP, el manejo de archivos (Resoluciones) y la bifurcación automática de estados según los escenarios de negocio definidos.

## Cambios Realizados (Backend)
* **Endpoint / Servicio:** Se creó el método `procesarSegundaCalificacion` en `ApelacionService`.
* **Subida de Archivos:** Se integró `FileStorageService` para recibir y guardar físicamente el PDF de la resolución firmada (`MultipartFile`), enlazándolo correctamente en la base de datos a través de la entidad `Documento`.
* **Limpieza de Entorno de Pruebas:** Se eliminó el archivo temporal `data.sql` y las configuraciones de inicialización de base de datos en `application.properties` para garantizar que la suite de pruebas del equipo corra en verde y sin conflictos de esquema en GitHub Actions.

## Flujo de Estados Implementado (BE-02)
Se agregó la lógica condicional que actualiza el estado de la apelación basándose en la decisión enviada desde el Frontend, cumpliendo estrictamente con los criterios Gherkin:
1. **Admitida (`ADMISIBLE`):** La apelación avanza al estado `EN_RESOLUCION` (Pasa a Calificación Final) y guarda la nota de calificación.
2. **No Subsanada (`TENER_POR_NO_PRESENTADO`):** La apelación queda como `TENER_POR_NO_PRESENTADO` y finaliza el proceso.
3. **Rechazo Definitivo (`IMPROCEDENTE`):** La apelación queda resuelta definitivamente con el estado `RESUELTO_IMPROCEDENTE`.

## Checklist
- [x] Lógica del servicio implementada.
- [x] Transición de estados (Bifurcación) testeada y validada.
- [x] Pruebas de subida de PDF validadas vía Postman (200 OK).
- [x] Compilación y tests en verde (GitHub Actions).

This pull request updates the logic for processing the "segunda calificación" (second evaluation) of an appeal in the `ApelacionService`. The main improvements are the addition of new decision types, clearer result messages, and always saving the provided "fundamentos" (reasoning) for any decision.

Decision processing enhancements:

* Added support for new decision types: `"ADMITIDO"` and `"NO_PRESENTADO"`/`"TENER_POR_NO_PRESENTADO"`, allowing more flexible handling of appeal outcomes.
* Updated the logic to set more descriptive result messages and the correct state for each decision, including new handling for "TENER POR NO PRESENTADO" and a more explicit rejection message for "IMPROCEDENTE".
* Now always saves the `fundamentos` (reasoning) from the request to the appeal, regardless of the decision taken.
* Improved input validation to reflect the expanded set of valid decisions, updating the exception message accordingly.