### PR TITLE
✨ feat(HU-07): BE-03 · Validar plazo 7 días 2ª calificación

### DIFF
--- a/transparencia-backend/src/main/java/com/transparencia/api/controller/TTAIPRestController.java
+++ b/transparencia-backend/src/main/java/com/transparencia/api/controller/TTAIPRestController.java
@@ -103,7 +103,7 @@ public class TTAIPRestController {
         return ResponseEntity.ok(ttaipService.declararTenerPorNoPresentado(apelacionId, request));
     }
 
-    // MÉTODO NUEVO PARA HU-07 (Segunda Calificación)
+    // MÉTODO PARA HU-07 (Segunda Calificación)
 
     @PostMapping(value = "/segunda-calificacion/{id}/notificar", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<?> notificarSegundaCalificacion(
@@ -119,5 +119,12 @@ public class TTAIPRestController {
         } catch (Exception e) {
             return ResponseEntity.internalServerError().body(Map.of("error", "Error interno al procesar la calificación."));
         }
+    }
+
+    // Endpoint para confirmar la notificación (HU-07 BE-02)
+    @PostMapping("/{id}/confirmar-notificacion")
+    public ResponseEntity<Apelacion> confirmarNotificacion(@PathVariable Long id) {
+        Apelacion apelacionActualizada = apelacionService.confirmarNotificacionSegundaCalificacion(id);
+        return ResponseEntity.ok(apelacionActualizada);
     }
 }

--- a/transparencia-backend/src/main/java/com/transparencia/api/service/ApelacionService.java
+++ b/transparencia-backend/src/main/java/com/transparencia/api/service/ApelacionService.java
@@ -1,5 +1,7 @@
 package com.transparencia.api.service;
 
+import com.transparencia.api.util.DiasHabilesUtil;
+import java.time.LocalDate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -31,7 +33,7 @@ public class ApelacionService {
     private final DocumentoRepository documentoRepository;
     private final FileStorageService fileStorageService;
 
-    //  inyecciones para soportar archivos
+    // Inyecciones para soportar archivos
     public ApelacionService(ApelacionRepository apelacionRepository,
                             DocumentoRepository documentoRepository,
                             FileStorageService fileStorageService) {
@@ -101,7 +103,6 @@ public class ApelacionService {
     }
 
     // MÉTODO PARA HU-07 (Segunda Calificación)
-
     @Transactional
     public Apelacion procesarSegundaCalificacion(Long idApelacion, SegundaCalificacionDTO request, MultipartFile archivoAdjunto) {
         Apelacion apelacion = apelacionRepository.findById(idApelacion)
@@ -111,6 +112,20 @@ public class ApelacionService {
         if (apelacion.getEstado() != Apelacion.EstadoApelacion.EN_CALIFICACION_2) {
             throw new IllegalStateException("La apelación no se encuentra en Segunda Calificación.");
         }
+
+        // Validar plazo de 7 días hábiles
+        LocalDate fechaInicio = apelacion.getFechaSubsanacion() != null
+                ? apelacion.getFechaSubsanacion().toLocalDate()
+                : apelacion.getFechaApelacion().toLocalDate();
+
+        int diasTranscurridos = DiasHabilesUtil.contarDiasHabiles(fechaInicio, LocalDate.now());
+
+        // Si se pasó del plazo, se crea una etiqueta de advertencia para la auditoría
+        String sufijoPlazo = "";
+        if (diasTranscurridos > 7) {
+            sufijoPlazo = " (ALERTA: FUERA DE PLAZO REGLAMENTARIO - " + diasTranscurridos + " días)";
+        }
+
 
         // El archivo de resolución es obligatorio
         if (archivoAdjunto == null || archivoAdjunto.isEmpty()) {
@@ -127,22 +142,22 @@ public class ApelacionService {
 
         documentoRepository.save(documento);
 
-        // Flujo parametrizado según decisión (HU-07 BE-02)
+        // Flujo parametrizado según decisión
         if ("ADMISIBLE".equalsIgnoreCase(request.getDecision()) || "ADMITIDO".equalsIgnoreCase(request.getDecision())) {
-            // Pasa a Calificación Final (En Resolución)
-            apelacion.setEstado(Apelacion.EstadoApelacion.EN_RESOLUCION);
-            apelacion.setResultado("ADMITIDO EN SEGUNDA CALIFICACIÓN");
+            // Pasa a estado de Notificación
+            apelacion.setEstado(Apelacion.EstadoApelacion.NOTIFICACION_SEGUNDA_CALIFICACION);
+            apelacion.setResultado("ADMITIDO EN SEGUNDA CALIFICACIÓN" + sufijoPlazo);
             apelacion.setCalificacionSegunda(Apelacion.Calificacion.ADMISIBLE);
 
         } else if ("TENER_POR_NO_PRESENTADO".equalsIgnoreCase(request.getDecision()) || "NO_PRESENTADO".equalsIgnoreCase(request.getDecision())) {
             // El ciudadano no subsanó a tiempo
             apelacion.setEstado(Apelacion.EstadoApelacion.TENER_POR_NO_PRESENTADO);
-            apelacion.setResultado("TENER POR NO PRESENTADO POR FALTA DE SUBSANACIÓN");
+            apelacion.setResultado("TENER POR NO PRESENTADO POR FALTA DE SUBSANACIÓN" + sufijoPlazo);
 
         } else if ("IMPROCEDENTE".equalsIgnoreCase(request.getDecision())) {
             // Cierre definitivo como Improcedente
             apelacion.setEstado(Apelacion.EstadoApelacion.RESUELTO_IMPROCEDENTE);
-            apelacion.setResultado("RECHAZO DEFINITIVO - IMPROCEDENTE");
+            apelacion.setResultado("RECHAZO DEFINITIVO - IMPROCEDENTE" + sufijoPlazo);
             apelacion.setCalificacionSegunda(Apelacion.Calificacion.IMPROCEDENTE);
 
         } else {
@@ -152,6 +167,21 @@ public class ApelacionService {
         // Guardar los fundamentos sin importar qué decisión se tomó
         apelacion.setFundamentos(request.getFundamentos());
 
+        return apelacionRepository.save(apelacion);
+    }
+
+    // MÉTODO EXTRA: Para confirmar la notificación y pasar a Resolución Final (BE-02)
+    @Transactional
+    public Apelacion confirmarNotificacionSegundaCalificacion(Long idApelacion) {
+        Apelacion apelacion = apelacionRepository.findById(idApelacion)
+                .orElseThrow(() -> new RuntimeException("Apelación no encontrada con ID: " + idApelacion));
+
+        if (apelacion.getEstado() != Apelacion.EstadoApelacion.NOTIFICACION_SEGUNDA_CALIFICACION) {
+            throw new IllegalStateException("La apelación no está pendiente de notificación.");
+        }
+
+        // Avanza la etapa de resolución
+        apelacion.setEstado(Apelacion.EstadoApelacion.EN_RESOLUCION);
         return apelacionRepository.save(apelacion);
     }
 }


### PR DESCRIPTION
## Objetivo de la Historia de Usuario
Implementar el "cerebro" (Backend) para la **HU-07: Emitir Respuesta de Segunda Calificación**. Se han integrado los endpoints, el manejo de archivos multipart, la bifurcación automática de estados según la decisión del TTAIP y las reglas de validación de plazos reglamentarios.

## Cambios Realizados (Backend)
* **Nuevos Endpoints (`TTAIPRestController`):** * `POST /api/ttaip/segunda-calificacion/{id}/notificar`: Recibe el formulario (`SegundaCalificacionDTO`) y el documento PDF firmado (`MultipartFile`) [BE-01].
  * `POST /api/ttaip/{id}/confirmar-notificacion`: Permite al TTAIP confirmar que el ciudadano fue notificado para avanzar al estado de resolución final.
* **Gestión de Archivos:** Se integró `FileStorageService` para guardar físicamente la resolución del TTAIP y registrarla en la base de datos como tipo `RESOLUCION_TTAIP`.

## Flujo de Estados y Reglas de Negocio Implementadas

1. **Bifurcación de Decisión (BE-02):**
   * **Admitido:** La apelación avanza a `NOTIFICACION_SEGUNDA_CALIFICACION`. Una vez confirmada la notificación, pasa a `EN_RESOLUCION` (Calificación Final).
   * **No Subsanada:** Queda como `TENER_POR_NO_PRESENTADO` y finaliza el proceso.
   * **Rechazo Definitivo:** Queda resuelta definitivamente con el estado `RESUELTO_IMPROCEDENTE`.
2. **Control de Plazo de 7 Días Hábiles (BE-03):** * Se integró `DiasHabilesUtil` para calcular el tiempo transcurrido desde la recepción.
   * **Diseño No Bloqueante:** Si el TTAIP supera los 7 días, el sistema permite guardar la resolución para no detener el trámite del ciudadano, pero inyecta automáticamente una etiqueta de auditoría `(ALERTA: FUERA DE PLAZO REGLAMENTARIO)` en el resultado de la base de datos.

## Checklist de Criterios de Aceptación
- [x] Endpoints creados y asegurados (BE-01).
- [x] Bifurcación de estados implementada y validada (BE-02).
- [x] Regla de los 7 días hábiles implementada como advertencia (BE-03).
- [x] Código limpio, sin advertencias críticas y subido correctamente.


This pull request introduces enhancements and new functionality for handling the "Segunda Calificación" (Second Evaluation) workflow in the appeals process. The main improvements include stricter deadline validation, more informative status results, and a new endpoint for confirming notification, which advances the appeal to its final resolution stage.

**Enhancements to Segunda Calificación workflow:**

* Added validation for the 7-business-day deadline in `procesarSegundaCalificacion`, including a warning suffix in the result if the deadline is missed. [[1]](diffhunk://#diff-5ec523312f1b9ea625101090f722d9c08d6b97c921af3b6175ecbc6b028b87f0R116-R129) [[2]](diffhunk://#diff-5ec523312f1b9ea625101090f722d9c08d6b97c921af3b6175ecbc6b028b87f0L130-R160)
* Updated state transitions and result messages to reflect deadline status and ensure accurate tracking of appeal progress.

**New functionality:**

* Introduced a new endpoint `/apelaciones/{id}/confirmar-notificacion` in `TTAIPRestController` to allow confirmation of notification for the second evaluation, advancing the appeal to the resolution stage. [[1]](diffhunk://#diff-88e960585c2c7d1ffdfaa6057ae3e6997d8d9b0d641cdec1e0b79ee8891bcf6bR123-R129) [[2]](diffhunk://#diff-5ec523312f1b9ea625101090f722d9c08d6b97c921af3b6175ecbc6b028b87f0R172-R186)
* Implemented the `confirmarNotificacionSegundaCalificacion` method in `ApelacionService` to support this new endpoint and update the appeal's state accordingly.

**Minor improvements:**

* Improved code comments and formatting for clarity and consistency. [[1]](diffhunk://#diff-88e960585c2c7d1ffdfaa6057ae3e6997d8d9b0d641cdec1e0b79ee8891bcf6bL106-R106) [[2]](diffhunk://#diff-5ec523312f1b9ea625101090f722d9c08d6b97c921af3b6175ecbc6b028b87f0L34-R36) [[3]](diffhunk://#diff-5ec523312f1b9ea625101090f722d9c08d6b97c921af3b6175ecbc6b028b87f0L104)
* Added necessary imports for business day calculation utilities.