### PR TITLE
Cierre técnico HU-07: Corrección de bucle infinito JSON y activación …

### DIFF
--- a/transparencia-backend/src/main/java/com/transparencia/api/controller/TTAIPRestController.java
+++ b/transparencia-backend/src/main/java/com/transparencia/api/controller/TTAIPRestController.java
@@ -61,9 +61,9 @@ public class TTAIPRestController {
         return ResponseEntity.ok(ttaipService.listarPorEstado(Apelacion.EstadoApelacion.EN_CALIFICACION_2));
     }
 
-    @GetMapping("/en-resolucion")
-    public ResponseEntity<List<ApelacionDTO>> listarEnResolucion() {
-        return ResponseEntity.ok(ttaipService.listarPorEstado(Apelacion.EstadoApelacion.EN_RESOLUCION));
+    @GetMapping("/en-proceso")
+    public ResponseEntity<List<ApelacionDTO>> listarEnProceso() {
+        return ResponseEntity.ok(ttaipService.listarEnProceso());
     }
 
     @GetMapping("/resueltas")
@@ -126,5 +126,13 @@ public class TTAIPRestController {
     public ResponseEntity<Apelacion> confirmarNotificacion(@PathVariable Long id) {
         Apelacion apelacionActualizada = apelacionService.confirmarNotificacionSegundaCalificacion(id);
         return ResponseEntity.ok(apelacionActualizada);
+    }
+
+    @GetMapping("/todas")
+    public ResponseEntity<List<ApelacionDTO>> listarTodas() {
+        // Usa el findAll que ya existe en apelacionService
+        return ResponseEntity.ok(apelacionService.findAll().stream()
+                .map(ApelacionDTO::from)
+                .toList());
     }
 }

--- a/transparencia-backend/src/main/java/com/transparencia/api/model/dto/ApelacionDTO.java
+++ b/transparencia-backend/src/main/java/com/transparencia/api/model/dto/ApelacionDTO.java
@@ -17,6 +17,7 @@ public class ApelacionDTO {
     private String ciudadanoNombre;
     private Long solicitudId;
     private String solicitudExpediente;
+    private String entidadNombre;
 
     public static ApelacionDTO from(Apelacion apelacion) {
         ApelacionDTO dto = new ApelacionDTO();
@@ -28,15 +29,25 @@ public class ApelacionDTO {
         dto.setFechaSubsanacion(apelacion.getFechaSubsanacion());
         dto.setDiasSubsanacion(apelacion.getDiasSubsanacion());
 
+        // Mapeo del Ciudadano
         if (apelacion.getCiudadano() != null) {
             dto.setCiudadanoId(apelacion.getCiudadano().getIdUsuario());
             dto.setCiudadanoNombre(apelacion.getCiudadano().getNombreCompleto());
         }
 
+        // Mapeo de la Solicitud
         if (apelacion.getSolicitud() != null) {
             dto.setSolicitudId(apelacion.getSolicitud().getIdSolicitud());
             dto.setSolicitudExpediente(apelacion.getSolicitud().getExpediente());
         }
+
+        // --- LÓGICA PARA LA ENTIDAD ---
+        if (apelacion.getEntidad() != null) {
+            dto.setEntidadNombre(apelacion.getEntidad().getNombre());
+        } else {
+            dto.setEntidadNombre("Sin Entidad");
+        }
+        // ------------------------------------
 
         return dto;
     }

--- a/transparencia-backend/src/main/java/com/transparencia/api/model/entity/Apelacion.java
+++ b/transparencia-backend/src/main/java/com/transparencia/api/model/entity/Apelacion.java
@@ -30,6 +30,10 @@ public class Apelacion {
     @JoinColumn(name = "id_ciudadano")
     private Ciudadano ciudadano;
 
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "id_entidad")
+    private Entidad entidad;
+
     @Column(columnDefinition = "TEXT")
     private String fundamentos;
 

--- a/transparencia-backend/src/main/java/com/transparencia/api/model/entity/Documento.java
+++ b/transparencia-backend/src/main/java/com/transparencia/api/model/entity/Documento.java
@@ -1,5 +1,6 @@
 package com.transparencia.api.model.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -59,10 +60,12 @@ public class Documento {
     @JoinColumn(name = "id_respuesta")
     private Respuesta respuesta;
 
+    @JsonIgnore
     @ManyToOne
     @JoinColumn(name = "id_apelacion")
     private Apelacion apelacion;
 
+    @JsonIgnore
     @ManyToOne
     @JoinColumn(name = "id_resolucion")
     private Resolucion resolucion;

--- a/transparencia-backend/src/main/java/com/transparencia/api/service/ApelacionService.java
+++ b/transparencia-backend/src/main/java/com/transparencia/api/service/ApelacionService.java
@@ -110,7 +110,7 @@ public class ApelacionService {
 
         // La apelación debe estar en Segunda Calificación
         if (apelacion.getEstado() != Apelacion.EstadoApelacion.EN_CALIFICACION_2) {
-            throw new IllegalStateException("Error - ID recibido: " + idApelacion + " | Estado en BD: " + apelacion.getEstado());
+            throw new IllegalStateException("La apelación no se encuentra en Segunda Calificación.");
         }
 
         // Validar plazo de 7 días hábiles

--- a/transparencia-backend/src/main/java/com/transparencia/api/service/ApelacionService.java
+++ b/transparencia-backend/src/main/java/com/transparencia/api/service/ApelacionService.java
@@ -110,7 +110,7 @@ public class ApelacionService {
 
         // La apelación debe estar en Segunda Calificación
         if (apelacion.getEstado() != Apelacion.EstadoApelacion.EN_CALIFICACION_2) {
-            throw new IllegalStateException("La apelación no se encuentra en Segunda Calificación.");
+            throw new IllegalStateException("Error - ID recibido: " + idApelacion + " | Estado en BD: " + apelacion.getEstado());
         }
 
         // Validar plazo de 7 días hábiles

--- a/transparencia-backend/src/main/java/com/transparencia/api/service/TTAIPService.java
+++ b/transparencia-backend/src/main/java/com/transparencia/api/service/TTAIPService.java
@@ -51,29 +51,35 @@ public class TTAIPService {
         Map<String, Object> stats = new HashMap<>();
         stats.put("total", apelacionService.count());
 
+        // 1. Pendientes de Admisión (Solo etapa inicial)
         long pendientes =
-            apelacionService.contarApelacionesPorEstado(Apelacion.EstadoApelacion.PENDIENTE_ELEVACION)
-                + apelacionService.contarApelacionesPorEstado(Apelacion.EstadoApelacion.EN_CALIFICACION_1);
+                apelacionService.contarApelacionesPorEstado(Apelacion.EstadoApelacion.PENDIENTE_ELEVACION)
+                        + apelacionService.contarApelacionesPorEstado(Apelacion.EstadoApelacion.EN_CALIFICACION_1);
         stats.put("pendientes", pendientes);
 
+        // 2. En Proceso (Solo los que están listos para Resolución Final)
         long enProceso =
-            apelacionService.contarApelacionesPorEstado(Apelacion.EstadoApelacion.EN_CALIFICACION_2)
-                + apelacionService.contarApelacionesPorEstado(Apelacion.EstadoApelacion.NOTIFICACION_SEGUNDA_CALIFICACION)
-                + apelacionService.contarApelacionesPorEstado(Apelacion.EstadoApelacion.EN_RESOLUCION);
+                apelacionService.contarApelacionesPorEstado(Apelacion.EstadoApelacion.NOTIFICACION_SEGUNDA_CALIFICACION)
+                        + apelacionService.contarApelacionesPorEstado(Apelacion.EstadoApelacion.EN_RESOLUCION);
         stats.put("enProceso", enProceso);
 
+        // 3. En Subsanación
         stats.put("enSubsanacion", apelacionService.contarApelacionesPorEstado(Apelacion.EstadoApelacion.EN_SUBSANACION));
 
+        // 4. Segunda Calificación (¡NUEVO! Separado para tu HU-07)
+        stats.put("segundaCalificacion", apelacionService.contarApelacionesPorEstado(Apelacion.EstadoApelacion.EN_CALIFICACION_2));
+
+        // 5. Resueltas
         long resueltas =
-            apelacionService.contarApelacionesPorEstado(Apelacion.EstadoApelacion.RESUELTO)
-                + apelacionService.contarApelacionesPorEstado(Apelacion.EstadoApelacion.RESUELTO_FUNDADO)
-                + apelacionService.contarApelacionesPorEstado(Apelacion.EstadoApelacion.RESUELTO_FUNDADO_EN_PARTE)
-                + apelacionService.contarApelacionesPorEstado(Apelacion.EstadoApelacion.RESUELTO_INFUNDADO)
-                + apelacionService.contarApelacionesPorEstado(Apelacion.EstadoApelacion.RESUELTO_INFUNDADO_EN_PARTE)
-                + apelacionService.contarApelacionesPorEstado(Apelacion.EstadoApelacion.RESUELTO_IMPROCEDENTE)
-                + apelacionService.contarApelacionesPorEstado(Apelacion.EstadoApelacion.TENER_POR_NO_PRESENTADO)
-                + apelacionService.contarApelacionesPorEstado(Apelacion.EstadoApelacion.CONCLUSION_SUSTRACCION_MATERIA)
-                + apelacionService.contarApelacionesPorEstado(Apelacion.EstadoApelacion.CONCLUSION_DESISTIMIENTO);
+                apelacionService.contarApelacionesPorEstado(Apelacion.EstadoApelacion.RESUELTO)
+                        + apelacionService.contarApelacionesPorEstado(Apelacion.EstadoApelacion.RESUELTO_FUNDADO)
+                        + apelacionService.contarApelacionesPorEstado(Apelacion.EstadoApelacion.RESUELTO_FUNDADO_EN_PARTE)
+                        + apelacionService.contarApelacionesPorEstado(Apelacion.EstadoApelacion.RESUELTO_INFUNDADO)
+                        + apelacionService.contarApelacionesPorEstado(Apelacion.EstadoApelacion.RESUELTO_INFUNDADO_EN_PARTE)
+                        + apelacionService.contarApelacionesPorEstado(Apelacion.EstadoApelacion.RESUELTO_IMPROCEDENTE)
+                        + apelacionService.contarApelacionesPorEstado(Apelacion.EstadoApelacion.TENER_POR_NO_PRESENTADO)
+                        + apelacionService.contarApelacionesPorEstado(Apelacion.EstadoApelacion.CONCLUSION_SUSTRACCION_MATERIA)
+                        + apelacionService.contarApelacionesPorEstado(Apelacion.EstadoApelacion.CONCLUSION_DESISTIMIENTO);
         stats.put("resueltas", resueltas);
 
         return stats;
@@ -81,9 +87,14 @@ public class TTAIPService {
 
     @Transactional(readOnly = true)
     public List<ApelacionDTO> listarPendientes() {
-        return apelacionService.findPendientes().stream()
-            .map(ApelacionDTO::from)
-            .toList();
+        // Antes traía todo. Ahora traemos EXPLÍCITAMENTE solo los de primera calificación.
+        java.util.List<Apelacion> pendientesClasificados = new java.util.ArrayList<>();
+        pendientesClasificados.addAll(apelacionService.obtenerApelacionesPorEstado(Apelacion.EstadoApelacion.PENDIENTE_ELEVACION));
+        pendientesClasificados.addAll(apelacionService.obtenerApelacionesPorEstado(Apelacion.EstadoApelacion.EN_CALIFICACION_1));
+
+        return pendientesClasificados.stream()
+                .map(ApelacionDTO::from)
+                .toList();
     }
 
     @Transactional(readOnly = true)
@@ -216,6 +227,18 @@ public class TTAIPService {
         apelacionService.save(apelacion);
 
         return ApelacionDTO.from(apelacion);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ApelacionDTO> listarEnProceso() {
+
+        java.util.List<Apelacion> enProceso = new java.util.ArrayList<>();
+        enProceso.addAll(apelacionService.obtenerApelacionesPorEstado(Apelacion.EstadoApelacion.NOTIFICACION_SEGUNDA_CALIFICACION));
+        enProceso.addAll(apelacionService.obtenerApelacionesPorEstado(Apelacion.EstadoApelacion.EN_RESOLUCION));
+
+        return enProceso.stream()
+                .map(ApelacionDTO::from)
+                .toList();
     }
 
     private Apelacion buscarApelacion(Long apelacionId) {


### PR DESCRIPTION
Descripción:
Este Pull Request consolida los ajustes finales para la Historia de Usuario 07, asegurando la estabilidad del sistema y el cumplimiento del flujo de negocio.

Cambios principales:

Corrección de Bucle Infinito (Jackson): Se implementó la anotación @JsonIgnore en las entidades Documento y Resolucion. Esto soluciona el error de "nesting depth" que impedía la serialización de objetos hacia el Frontend debido a la relación bidireccional con Apelacion.

Activación del flujo de Notificación: Se configuró el componente de resolución para manejar el estado NOTIFICACION_SEGUNDA_CALIFICACION. Ahora la vista incluye una fase de validación previa que permite al funcionario confirmar los actos de notificación antes de habilitar el formulario de resolución final.

Vinculación con el Backend: Se conectó el botón de confirmación con el endpoint confirmar-notificacion del TTAIPRestController, garantizando que el cambio de estado a EN_RESOLUCION se registre correctamente en la base de datos.

Refactorización de Vistas: Se actualizaron las condiciones de renderizado en el Dashboard y en la pantalla de Resolución para reflejar los estados actuales del proceso de manera amigable para el usuario.

Pruebas realizadas:

Se verificó el registro exitoso de segundas calificaciones con carga de archivos PDF.

Se comprobó que el flujo de estados avance correctamente en la base de datos MySQL.

Se validó la desaparición del error 500 al retornar objetos desde la API.

This pull request introduces several improvements and adjustments to the handling of appeals (`Apelacion`) in the transparency backend. The main changes include refining the logic for listing and categorizing appeals by status, adding new endpoints for retrieving appeals, and enhancing data transfer objects to include additional related information.

**API and Service Layer Updates:**

* The `/en-proceso` endpoint replaces `/en-resolucion` and now uses a new service method to list appeals in process, specifically those in the "Notificación Segunda Calificación" or "En Resolución" states. [[1]](diffhunk://#diff-88e960585c2c7d1ffdfaa6057ae3e6997d8d9b0d641cdec1e0b79ee8891bcf6bL64-R66) [[2]](diffhunk://#diff-7451a61cca66806fee6c5ba55e4a78d3c4ff599b8631832466bad6fd3232153cR232-R243)
* A new `/todas` endpoint has been added to retrieve all appeals using the `findAll` method from the service.
* The logic for listing pending appeals now explicitly includes only those in the "Pendiente Elevación" and "En Calificación 1" states, improving clarity and accuracy.

**DTO and Entity Enhancements:**

* The `ApelacionDTO` now includes an `entidadNombre` field, which is mapped from the associated `Entidad` entity if available, or set to "Sin Entidad" otherwise. [[1]](diffhunk://#diff-268f7eff34238ba6f48cad8043ed36285fd1f721b9e8a453ac8c412942571741R20) [[2]](diffhunk://#diff-268f7eff34238ba6f48cad8043ed36285fd1f721b9e8a453ac8c412942571741R32-R51)
* The `Apelacion` entity now has an explicit relationship to the `Entidad` entity via a new field and JPA annotations.
* The `Documento` entity now uses `@JsonIgnore` for its relationships to `Apelacion` and `Resolucion` to prevent serialization issues. [[1]](diffhunk://#diff-49170e31f5a31fba897068c80cd03cf64de9c539f47b919f4a636b38984a250eR3) [[2]](diffhunk://#diff-49170e31f5a31fba897068c80cd03cf64de9c539f47b919f4a636b38984a250eR63-R68)

**Statistical and Error Handling Improvements:**

* The statistics method (`obtenerEstadisticas`) has been updated to provide more granular counts for appeals by their specific states, including a new separate count for "Segunda Calificación".
* Error messages in the `procesarSegundaCalificacion` method now include the received ID and the current state from the database for better debugging.…de flujo Notificación/Resolución