### PR TITLE
:sparkles: feat(HU-07): agregar interfaz para emitir la segunda calificacion TTAIP

### DIFF
--- a/transparencia-frontend/src/app/pages/ttaip/ttaip-segunda-calificacion.component.ts
+++ b/transparencia-frontend/src/app/pages/ttaip/ttaip-segunda-calificacion.component.ts
@@ -142,7 +142,7 @@ export class TtaipSegundaCalificacionComponent implements OnInit {
   private exito(msg: string): void {
     this.loading.set(false);
     this.mensaje.set(msg);
-    setTimeout(() => this.router.navigate(['/ttaip']), 2000);
+    setTimeout(() => this.router.navigate(['/ttaip/dashboard']), 2000);
   }
 
   private errorHandler(err: any): void {


### PR DESCRIPTION
## Descripción
Este Pull Request implementa la HU-07, permitiendo al Tribunal de Transparencia calificar las apelaciones que han pasado por el proceso de subsanación ciudadano.

**Cambios principales:**
- Añadido el componente `ttaip-segunda-calificacion` en el frontend.
- Conexión de la vista con los modelos de datos para la evaluación definitiva y cambio de estado a "Admitido" o "Rechazado".
