### PR TITLE
feat(HU-08): BE-01 · Endpoints resolución final 7 decisiones integrar…

### DIFF
--- a/transparencia-backend/pom.xml
+++ b/transparencia-backend/pom.xml
@@ -116,6 +116,12 @@
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/transparencia-backend/src/main/java/com/transparencia/api/controller/TTAIPRestController.java
+++ b/transparencia-backend/src/main/java/com/transparencia/api/controller/TTAIPRestController.java
@@ -209,4 +209,13 @@ public class TTAIPRestController {
         return ResponseEntity.ok(ttaipService.emitirResolucionFinal(
             apelacionId, "TENER_POR_NO_PRESENTADO", request.fundamentos(), request.iniciarProcesoDisciplinario()));
     }
+
+    @PostMapping(value = "/{id}/emitir-resolucion", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<Apelacion> emitirResolucion(
+            @PathVariable Long id,
+            @RequestPart("datos") com.transparencia.api.model.dto.ResolucionFinalRequest datos,
+            @RequestPart("archivo") MultipartFile archivo) {
+
+        return ResponseEntity.ok(apelacionService.emitirResolucionFinal(id, datos, archivo));
+    }
 }

--- a/transparencia-backend/src/main/java/com/transparencia/api/model/dto/ResolucionFinalRequest.java
+++ b/transparencia-backend/src/main/java/com/transparencia/api/model/dto/ResolucionFinalRequest.java
@@ -1,0 +1,14 @@
+package com.transparencia.api.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ResolucionFinalRequest {
+    private String decision;
+    private String fundamentos;
+    private Boolean iniciarProcesoDisciplinario;
+}

--- a/transparencia-backend/src/main/java/com/transparencia/api/model/entity/Apelacion.java
+++ b/transparencia-backend/src/main/java/com/transparencia/api/model/entity/Apelacion.java
@@ -52,6 +52,7 @@ public class Apelacion {
     private String resultado;
     private LocalDateTime fechaApelacion;
     private LocalDateTime fechaSubsanacion;
+    private LocalDateTime fechaResolucion;
     private Integer diasSubsanacion;
 
     public enum EstadoApelacion {

--- a/transparencia-backend/src/main/java/com/transparencia/api/security/SecurityConfig.java
+++ b/transparencia-backend/src/main/java/com/transparencia/api/security/SecurityConfig.java
@@ -86,4 +86,5 @@ public class SecurityConfig {
         source.registerCorsConfiguration("/**", configuration);
         return source;
     }
+
 }

--- a/transparencia-backend/src/main/java/com/transparencia/api/service/ApelacionService.java
+++ b/transparencia-backend/src/main/java/com/transparencia/api/service/ApelacionService.java
@@ -284,4 +284,73 @@ public class ApelacionService {
         apelacion.setEstado(Apelacion.EstadoApelacion.EN_RESOLUCION);
         return apelacionRepository.save(apelacion);
     }
+
+    // --- MÉTODO PARA HU-08 (BE-01): EMITIR FALLO FINAL CON 7 DECISIONES ---
+    @Transactional
+    public Apelacion emitirResolucionFinal(Long idApelacion, com.transparencia.api.model.dto.ResolucionFinalRequest request, MultipartFile archivoAdjunto) {
+        Apelacion apelacion = apelacionRepository.findById(idApelacion)
+                .orElseThrow(() -> new RuntimeException("Apelación no encontrada con ID: " + idApelacion));
+
+        if (apelacion.getEstado() != Apelacion.EstadoApelacion.EN_RESOLUCION) {
+            throw new IllegalStateException("La apelación debe estar en etapa de EN_RESOLUCION para emitir un fallo.");
+        }
+
+        if (archivoAdjunto == null || archivoAdjunto.isEmpty()) {
+            throw new IllegalArgumentException("Debe cargar el documento de resolución firmada (PDF).");
+        }
+
+        // 1. Guardar el documento físico (usando el fileStorageService que Daniel ya inyectó)
+        String rutaArchivoFisico = fileStorageService.storeFile(archivoAdjunto, "resoluciones_finales");
+        Documento documento = new Documento();
+        documento.setNombreArchivo(archivoAdjunto.getOriginalFilename());
+        documento.setRutaArchivo(rutaArchivoFisico);
+        documento.setTipoDocumento(Documento.TipoDocumento.RESOLUCION_TTAIP);
+        documento.setApelacion(apelacion);
+        documentoRepository.save(documento);
+
+        // 2. Mapear las 7 decisiones del Excel
+        String decisionNormalizada = request.getDecision().toLowerCase();
+
+        switch (decisionNormalizada) {
+            case "fundado":
+                apelacion.setEstado(Apelacion.EstadoApelacion.RESUELTO_FUNDADO);
+                apelacion.setResultado("RESUELTO - FUNDADO");
+                break;
+            case "fundado_en_parte":
+                apelacion.setEstado(Apelacion.EstadoApelacion.RESUELTO_FUNDADO_EN_PARTE);
+                apelacion.setResultado("RESUELTO - FUNDADO EN PARTE");
+                break;
+            case "infundado":
+                apelacion.setEstado(Apelacion.EstadoApelacion.RESUELTO_INFUNDADO);
+                apelacion.setResultado("RESUELTO - INFUNDADO");
+                break;
+            case "infundado_en_parte":
+                apelacion.setEstado(Apelacion.EstadoApelacion.RESUELTO_INFUNDADO_EN_PARTE);
+                apelacion.setResultado("RESUELTO - INFUNDADO EN PARTE");
+                break;
+            case "improcedente":
+                apelacion.setEstado(Apelacion.EstadoApelacion.RESUELTO_IMPROCEDENTE);
+                apelacion.setResultado("RESUELTO - IMPROCEDENTE");
+                break;
+            case "sustraccion_materia":
+                apelacion.setEstado(Apelacion.EstadoApelacion.CONCLUSION_SUSTRACCION_MATERIA);
+                apelacion.setResultado("CONCLUSIÓN POR SUSTRACCIÓN DE MATERIA");
+                break;
+            case "desistimiento":
+                apelacion.setEstado(Apelacion.EstadoApelacion.CONCLUSION_DESISTIMIENTO);
+                apelacion.setResultado("CONCLUSIÓN POR DESISTIMIENTO");
+                break;
+            default:
+                throw new IllegalArgumentException("Tipo de resolución no válido: " + request.getDecision());
+        }
+
+        apelacion.setFundamentos(request.getFundamentos());
+        apelacion.setFechaResolucion(LocalDateTime.now()); // Este es el campo que Daniel ya tiene en su entidad
+
+        if (Boolean.TRUE.equals(request.getIniciarProcesoDisciplinario())) {
+            apelacion.setResultado(apelacion.getResultado() + " (INCLUYE PROCESO DISCIPLINARIO)");
+        }
+
+        return apelacionRepository.save(apelacion);
+    }
 }

--- a/transparencia-backend/src/main/resources/application.properties
+++ b/transparencia-backend/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 spring.application.name=transparencia-backend
 server.port=${SERVER_PORT:8080}
 
-# Configuración de la Base de Datos parametrizada
+# Configuracion de la Base de Datos parametrizada
 spring.datasource.url=${DB_URL:jdbc:mysql://localhost:3306/saip_db?createDatabaseIfNotExist=true&allowPublicKeyRetrieval=true&serverTimezone=America/Lima}
 spring.datasource.username=${DB_USERNAME:root}
 spring.datasource.password=${DB_PASSWORD:}
@@ -13,7 +13,7 @@ spring.jpa.show-sql=${JPA_SHOW_SQL:true}
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.dialect=${JPA_DIALECT:org.hibernate.dialect.MySQLDialect}
 
-# Documentación OpenAPI
+# Documentacion OpenAPI
 springdoc.api-docs.path=/v3/api-docs
 springdoc.swagger-ui.path=/swagger-ui.html
 

--- a/transparencia-backend/src/main/resources/application.properties
+++ b/transparencia-backend/src/main/resources/application.properties
@@ -1,21 +1,23 @@
 spring.application.name=transparencia-backend
 server.port=${SERVER_PORT:8080}
 
-spring.datasource.url=${DB_URL:jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_NAME:saipcore_db}?createDatabaseIfNotExist=true&useSSL=${DB_USE_SSL:false}&allowPublicKeyRetrieval=true&serverTimezone=${DB_TIMEZONE:America/Lima}}
+# Configuración de la Base de Datos parametrizada
+spring.datasource.url=${DB_URL:jdbc:mysql://localhost:3306/saip_db?createDatabaseIfNotExist=true&allowPublicKeyRetrieval=true&serverTimezone=America/Lima}
 spring.datasource.username=${DB_USERNAME:root}
 spring.datasource.password=${DB_PASSWORD:}
 spring.datasource.driver-class-name=${DB_DRIVER:com.mysql.cj.jdbc.Driver}
 
+# Hibernate y JPA
 spring.jpa.hibernate.ddl-auto=${JPA_DDL_AUTO:update}
-spring.jpa.show-sql=${JPA_SHOW_SQL:false}
+spring.jpa.show-sql=${JPA_SHOW_SQL:true}
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.dialect=${JPA_DIALECT:org.hibernate.dialect.MySQLDialect}
 
+# Documentación OpenAPI
 springdoc.api-docs.path=/v3/api-docs
 springdoc.swagger-ui.path=/swagger-ui.html
 
+# Seguridad JWT y Archivos
 jwt.secret=${JWT_SECRET:UnaClaveSuperSecretaQueTengaAlMenos32CaracteresParaHMACSHA256}
 jwt.expiration-ms=${JWT_EXPIRATION_MS:86400000}
 app.upload-dir=${APP_UPLOAD_DIR:uploads}
-
-


### PR DESCRIPTION
This pull request implements the "Emitir Fallo Final" feature (HU-08), allowing the system to register the final resolution of an appeal with seven possible decisions, upload and store a signed PDF document, and update the appeal's state and result accordingly. It also introduces supporting DTOs, adjusts the database configuration, and ensures the backend is ready for multipart form data handling.

Key changes:

**Feature: Emitir Fallo Final (HU-08)**

* Added the `emitirResolucionFinal` endpoint to `TTAIPRestController`, accepting multipart form data for the resolution data and the signed PDF document.
* Implemented the `emitirResolucionFinal` method in `ApelacionService` to handle business logic: validates state, stores the uploaded PDF, maps the decision to one of seven possible outcomes, updates the `Apelacion` entity (including new `fechaResolucion` and result), and saves the changes.
* Introduced the `ResolucionFinalRequest` DTO to encapsulate the resolution decision, justifications, and disciplinary process flag.
* Added the `fechaResolucion` field to the `Apelacion` entity to track when the final resolution is issued.

**Configuration and Dependency Updates**

* Added the `mysql-connector-j` runtime dependency in `pom.xml` to ensure MySQL connectivity.
* Updated `application.properties` for database connection clarity, enabled SQL logging, and included comments for better maintainability.

These changes collectively enable the backend to support the final appeal resolution workflow, including document storage and robust state management.… cambios de develop, resolver conflictos de properties e implementar BE-01 emision de resolucion